### PR TITLE
refactor: 將 RAG retriever 改為參數注入 reader

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,3 +1,4 @@
+#  小註解：不從原有程式new物件，依賴dependency injection注入物件 那dependencies 就叫做 container
 import os
 
 from app.services.gemini import GeminiService, HealthClassifier

--- a/app/services/RAG/retriever.py
+++ b/app/services/RAG/retriever.py
@@ -1,12 +1,13 @@
 from typing import List
 
-from app.dependencies import get_vector_search_reader
-from .vector_search import ChunkHits
+from .vector_search import ChunkHits, MongoVectorSearchReader
 
 
-async def search_similar_chunks(query_embedding: List[float]) -> ChunkHits:
+async def search_similar_chunks(
+    query_embedding: List[float],
+    reader: MongoVectorSearchReader,
+) -> ChunkHits:
     # 這個 function 現在是被 script 的那邊呼叫
     # query_embedding：已算好的問題向量。取幾筆由 reader 內讀注入的 cfg.default_top_k。
     # Mongo 使用 Motor 非同步查詢，不阻塞 FastAPI / asyncio 事件迴圈。
-    reader = get_vector_search_reader()
     return await reader.search_by_embedding(query_embedding=query_embedding)

--- a/scripts/rag_query_cli.py
+++ b/scripts/rag_query_cli.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 
 load_dotenv(_PROJECT_ROOT / ".env")
 
+from app.dependencies import get_vector_search_reader
 from app.services.RAG.embedding_gemini import embed_query
 from app.services.RAG.retriever import search_similar_chunks
 
@@ -24,7 +25,7 @@ async def main() -> None:
         sys.exit(1)
 
     vec = await embed_query(question)
-    out = await search_similar_chunks(vec)
+    out = await search_similar_chunks(vec, reader=get_vector_search_reader())
     print(json.dumps(out, ensure_ascii=False, indent=2))
 
 


### PR DESCRIPTION
- retriever.search_similar_chunks 改為由呼叫端傳入 MongoVectorSearchReader
- 移除 retriever 對 app.dependencies 的直接依賴
- 更新 rag_query_cli 呼叫方式，改以 get_vector_search_reader() 注入 reader

Made-with: Cursor