### PR TITLE
refactor: 抽離 guardrail 分類邏輯為獨立 service

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,6 +3,7 @@ import os
 
 from app.services.gemini import GeminiService, HealthClassifier
 from app.orchestration import ResponseOrchestrator
+from app.services.guardrail import GuardrailService
 from app.services.RAG.retrieval import RagAnswerService
 from app.services.line.message_service import LineMessageService
 from app.services.RAG.shared.vector_search import (
@@ -14,6 +15,7 @@ mongodb_url = os.getenv("MONGODB_URL")
 
 _gemini_service = GeminiService()
 _health_classifier = HealthClassifier(gemini_service=_gemini_service)
+_guardrail_service = GuardrailService(gemini_service=_gemini_service)
 _vector_search_config = VectorSearchConfig.from_settings()
 _vector_search_reader = MongoVectorSearchReader(_vector_search_config)
 _rag_answer_service = RagAnswerService(
@@ -22,7 +24,7 @@ _rag_answer_service = RagAnswerService(
 )
 _response_orchestrator = ResponseOrchestrator(
     gemini_service=_gemini_service,
-    health_classifier=_health_classifier,
+    guardrail_service=_guardrail_service,
     rag_answer_service=_rag_answer_service,
 )
 _line_message_service = LineMessageService(
@@ -43,6 +45,10 @@ def get_gemini_service() -> GeminiService:
 
 def get_health_classifier() -> HealthClassifier:
     return _health_classifier
+
+
+def get_guardrail_service() -> GuardrailService:
+    return _guardrail_service
 
 
 def get_line_message_service() -> LineMessageService:

--- a/app/orchestration/response_orchestrator.py
+++ b/app/orchestration/response_orchestrator.py
@@ -1,6 +1,7 @@
 import logging
 
-from app.services.gemini import GeminiResult, GeminiService, HealthClassifier
+from app.services.gemini import GeminiResult, GeminiService
+from app.services.guardrail import GuardrailService
 from app.services.RAG.retrieval import RagAnswerService
 from app.tools.registry import get_all_gemini_tools
 
@@ -11,19 +12,19 @@ class ResponseOrchestrator:
     def __init__(
         self,
         gemini_service: GeminiService,
-        health_classifier: HealthClassifier,
+        guardrail_service: GuardrailService,
         rag_answer_service: RagAnswerService,
     ) -> None:
         self.gemini_service = gemini_service
-        self.health_classifier = health_classifier
+        self.guardrail_service = guardrail_service
         self.rag_answer_service = rag_answer_service
 
-    async def route_response(self, user_text: str) -> GeminiResult:
-        classification = await self.health_classifier.classify(user_text)
+    async def orchestrate_response(self, user_text: str) -> GeminiResult:
+        allow_rag_tool = await self.guardrail_service.allow_rag_tool(user_text)
         result = await self.gemini_service.generate_response(
             user_text,
             tools=get_all_gemini_tools(
-                include_rag_tool=classification.is_health_related
+                include_rag_tool=allow_rag_tool
             ),
         )
 
@@ -32,10 +33,6 @@ class ResponseOrchestrator:
 
         if result.function_name != "get_rag_answer":
             return result
-
-        if not classification.is_health_related:
-            logger.warning("偵測到非健康問題嘗試呼叫 RAG tool，改走一般 Gemini 回覆")
-            return await self.gemini_service.generate_response(user_text)
 
         query = str(result.function_args.get("query") or user_text).strip()
         try:

--- a/app/services/guardrail/__init__.py
+++ b/app/services/guardrail/__init__.py
@@ -1,0 +1,8 @@
+from .service import GuardrailService
+from .config import CLASSIFICATION_GENERATION_CONFIG, CLASSIFICATION_PROMPT
+
+__all__ = [
+    "CLASSIFICATION_GENERATION_CONFIG",
+    "CLASSIFICATION_PROMPT",
+    "GuardrailService",
+]

--- a/app/services/guardrail/config.py
+++ b/app/services/guardrail/config.py
@@ -1,0 +1,19 @@
+CLASSIFICATION_PROMPT = (
+    "你是一個訊息分類器。請判斷以下使用者訊息是否與「健康、醫療、身體狀況、疾病、藥物、營養、運動健身、心理健康」相關。\n\n"
+    "使用者訊息：\n"
+)
+
+CLASSIFICATION_GENERATION_CONFIG = {
+    "temperature": 0.1,
+    "maxOutputTokens": 200,
+    "responseMimeType": "application/json",
+    "responseSchema": {
+        "type": "object",
+        "properties": {
+            "is_health_related": {
+                "type": "boolean",
+            }
+        },
+        "required": ["is_health_related"],
+    },
+}

--- a/app/services/guardrail/service.py
+++ b/app/services/guardrail/service.py
@@ -1,0 +1,51 @@
+import logging
+
+from app.services.guardrail.config import (
+    CLASSIFICATION_GENERATION_CONFIG,
+    CLASSIFICATION_PROMPT,
+)
+from app.services.gemini.client.service import GeminiService
+from app.services.gemini.shared.errors import (
+    GeminiHttpError,
+    GeminiNetworkError,
+    GeminiParseError,
+    GeminiSchemaError,
+    GeminiUnknownError,
+)
+from app.services.gemini.shared.parser import parse_json_from_model_text
+
+logger = logging.getLogger(__name__)
+
+class GuardrailService:
+    def __init__(self, gemini_service: GeminiService) -> None:
+        self.gemini_service = gemini_service
+
+    async def allow_rag_tool(self, user_text: str) -> bool:
+        payload = {
+            "contents": [{"parts": [{"text": f"{CLASSIFICATION_PROMPT}{user_text}"}]}],
+            "generationConfig": CLASSIFICATION_GENERATION_CONFIG,
+        }
+
+        try:
+            data = await self.gemini_service.generate_content(payload, timeout=30.0)
+            raw_text = data["candidates"][0]["content"]["parts"][0]["text"]
+            parsed = parse_json_from_model_text(raw_text)
+            return bool(parsed.get("is_health_related", True))
+        except GeminiParseError as e:
+            logger.warning(f"Guardrail 分類解析失敗: {e}")
+            return True
+        except GeminiNetworkError as e:
+            logger.error(f"Guardrail 分類失敗（網路錯誤）: {e}")
+            return True
+        except GeminiHttpError as e:
+            logger.error(f"Guardrail 分類失敗（HTTP 錯誤）: {e}")
+            return True
+        except GeminiSchemaError as e:
+            logger.error(f"Guardrail 分類失敗（回應格式錯誤）: {e}")
+            return True
+        except GeminiUnknownError as e:
+            logger.error(f"Guardrail 分類失敗（未知錯誤）: {e}")
+            return True
+        except Exception as e:
+            logger.error(f"Guardrail 分類失敗（未處理錯誤）: {e}")
+            return True

--- a/app/services/line/message_service.py
+++ b/app/services/line/message_service.py
@@ -30,7 +30,7 @@ class LineMessageService:
     ) -> bool:
         try:
             logger.info(f"Processing message from user {user_id}: {user_text[:50]}...")
-            result = await self.response_orchestrator.route_response(user_text)
+            result = await self.response_orchestrator.orchestrate_response(user_text)
 
             if result.is_function_call and result.function_name == "request_location":
                 return await self.send_location_quick_reply(reply_token, user_id)

--- a/scripts/classifier_query_cli.py
+++ b/scripts/classifier_query_cli.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 
 load_dotenv(_PROJECT_ROOT / ".env")
 
-from app.dependencies import get_health_classifier
+from app.dependencies import get_guardrail_service
 
 
 async def main() -> None:
@@ -21,12 +21,12 @@ async def main() -> None:
         print("問題不能為空。", file=sys.stderr)
         sys.exit(1)
 
-    classifier = get_health_classifier()
-    result = await classifier.classify(question)
+    guardrail = get_guardrail_service()
+    is_health_related = await guardrail.allow_rag_tool(question)
 
     output = {
         "question": question,
-        "is_health_related": result.is_health_related,
+        "is_health_related": is_health_related,
     }
     print(json.dumps(output, ensure_ascii=False, indent=2))
 

--- a/tests/unit/test_message_service.py
+++ b/tests/unit/test_message_service.py
@@ -18,7 +18,7 @@ def mock_send_reply():
 async def test_process_success(mock_send_reply):
     # router 回傳一般文字（非 function call）
     mock_response_orchestrator = MagicMock()
-    mock_response_orchestrator.route_response = AsyncMock(
+    mock_response_orchestrator.orchestrate_response = AsyncMock(
         return_value=GeminiResult(text="AI 回覆")
     )
     svc = LineMessageService(response_orchestrator=mock_response_orchestrator)
@@ -38,7 +38,7 @@ async def test_process_function_call_request_location(mock_send_reply):
         return_value=True,
     ) as mock_quick_reply:
         mock_response_orchestrator = MagicMock()
-        mock_response_orchestrator.route_response = AsyncMock(
+        mock_response_orchestrator.orchestrate_response = AsyncMock(
             return_value=GeminiResult(function_name="request_location")
         )
         svc = LineMessageService(response_orchestrator=mock_response_orchestrator)
@@ -55,7 +55,7 @@ async def test_process_function_call_request_location(mock_send_reply):
 async def test_process_fallback_on_value_error(mock_send_reply):
     # router 發生錯誤時，應送出 fallback 訊息
     mock_response_orchestrator = MagicMock()
-    mock_response_orchestrator.route_response = AsyncMock(side_effect=ValueError("API 錯誤"))
+    mock_response_orchestrator.orchestrate_response = AsyncMock(side_effect=ValueError("API 錯誤"))
     svc = LineMessageService(response_orchestrator=mock_response_orchestrator)
     ok = await svc.process_and_reply("hi", "reply_token_xxx")
 

--- a/tests/unit/test_response_router.py
+++ b/tests/unit/test_response_router.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from app.services.gemini import ClassificationResult, GeminiResult
+from app.services.gemini import GeminiResult
 from app.orchestration.response_orchestrator import ResponseOrchestrator
 
 
@@ -9,19 +9,17 @@ from app.orchestration.response_orchestrator import ResponseOrchestrator
 async def test_route_response_text_uses_gemini_directly():
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock(return_value=GeminiResult(text="一般回覆"))
-    health_classifier = MagicMock()
-    health_classifier.classify = AsyncMock(
-        return_value=ClassificationResult(is_health_related=False)
-    )
+    guardrail_service = MagicMock()
+    guardrail_service.allow_rag_tool = AsyncMock(return_value=False)
     rag_answer_service = MagicMock()
 
     orchestrator = ResponseOrchestrator(
         gemini_service=gemini_service,
-        health_classifier=health_classifier,
+        guardrail_service=guardrail_service,
         rag_answer_service=rag_answer_service,
     )
 
-    result = await orchestrator.route_response("今天天氣如何")
+    result = await orchestrator.orchestrate_response("今天天氣如何")
     assert result.text == "一般回覆"
 
 
@@ -34,20 +32,18 @@ async def test_route_response_calls_rag_tool():
             function_args={"query": "我有高血壓要注意什麼"},
         )
     )
-    health_classifier = MagicMock()
-    health_classifier.classify = AsyncMock(
-        return_value=ClassificationResult(is_health_related=True)
-    )
+    guardrail_service = MagicMock()
+    guardrail_service.allow_rag_tool = AsyncMock(return_value=True)
     rag_answer_service = MagicMock()
     rag_answer_service.answer = AsyncMock(return_value="RAG 回覆")
 
     orchestrator = ResponseOrchestrator(
         gemini_service=gemini_service,
-        health_classifier=health_classifier,
+        guardrail_service=guardrail_service,
         rag_answer_service=rag_answer_service,
     )
 
-    result = await orchestrator.route_response("我有高血壓要注意什麼")
+    result = await orchestrator.orchestrate_response("我有高血壓要注意什麼")
 
     assert result.text == "RAG 回覆"
 
@@ -61,20 +57,18 @@ async def test_route_response_rag_tool_fallbacks_to_gemini_when_rag_fails():
             GeminiResult(text="一般回覆"),
         ]
     )
-    health_classifier = MagicMock()
-    health_classifier.classify = AsyncMock(
-        return_value=ClassificationResult(is_health_related=True)
-    )
+    guardrail_service = MagicMock()
+    guardrail_service.allow_rag_tool = AsyncMock(return_value=True)
     rag_answer_service = MagicMock()
     rag_answer_service.answer = AsyncMock(side_effect=RuntimeError("RAG failed"))
 
     orchestrator = ResponseOrchestrator(
         gemini_service=gemini_service,
-        health_classifier=health_classifier,
+        guardrail_service=guardrail_service,
         rag_answer_service=rag_answer_service,
     )
 
-    result = await orchestrator.route_response("我有高血壓要注意什麼")
+    result = await orchestrator.orchestrate_response("我有高血壓要注意什麼")
     assert result.text == "一般回覆"
 
 
@@ -82,19 +76,17 @@ async def test_route_response_rag_tool_fallbacks_to_gemini_when_rag_fails():
 async def test_route_response_non_health_disables_rag_tool():
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock(return_value=GeminiResult(text="一般回覆"))
-    health_classifier = MagicMock()
-    health_classifier.classify = AsyncMock(
-        return_value=ClassificationResult(is_health_related=False)
-    )
+    guardrail_service = MagicMock()
+    guardrail_service.allow_rag_tool = AsyncMock(return_value=False)
     rag_answer_service = MagicMock()
 
     orchestrator = ResponseOrchestrator(
         gemini_service=gemini_service,
-        health_classifier=health_classifier,
+        guardrail_service=guardrail_service,
         rag_answer_service=rag_answer_service,
     )
 
-    result = await orchestrator.route_response("今天天氣如何")
+    result = await orchestrator.orchestrate_response("今天天氣如何")
     assert result.text == "一般回覆"
     gemini_service.generate_response.assert_awaited_once()
     _, kwargs = gemini_service.generate_response.await_args


### PR DESCRIPTION
將工具前置判斷集中到 GuardrailService，orchestrator 改為只依賴 guardrail 決策結果與回覆流程。同步更新 CLI 與測試，避免再透過 gemini/classifier 直接做 guardrail 分類。

Made-with: Cursor