### PR TITLE
refactor(di): inject Gemini and RAG dependencies explicitly

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,10 +1,12 @@
 #  小註解：不從原有程式new物件，依賴dependency injection注入物件 那dependencies 就叫做 container
 import os
 
+from app.core.config import settings
 from app.services.gemini import GeminiService
 from app.orchestration import ResponseOrchestrator
 from app.services.guardrail import GuardrailService
-from app.services.RAG.retrieval import RagAnswerService
+from app.services.RAG.client import embed_query
+from app.services.RAG.retrieval import RagAnswerService, search_similar_chunks
 from app.services.line.message_service import LineMessageService
 from app.services.RAG.shared.vector_search import (
     MongoVectorSearchReader,
@@ -13,13 +15,18 @@ from app.services.RAG.shared.vector_search import (
 
 mongodb_url = os.getenv("MONGODB_URL")
 
-_gemini_service = GeminiService()
+_gemini_service = GeminiService(
+    api_key=settings.GEMINI_API_KEY,
+    model_name=settings.MODEL_NAME,
+)
 _guardrail_service = GuardrailService(gemini_service=_gemini_service)
 _vector_search_config = VectorSearchConfig.from_settings()
 _vector_search_reader = MongoVectorSearchReader(_vector_search_config)
 _rag_answer_service = RagAnswerService(
     gemini_service=_gemini_service,
     vector_search_reader=_vector_search_reader,
+    embed_query_fn=embed_query,
+    search_similar_chunks_fn=search_similar_chunks,
 )
 _response_orchestrator = ResponseOrchestrator(
     gemini_service=_gemini_service,

--- a/app/services/RAG/retrieval/rag_answer_service.py
+++ b/app/services/RAG/retrieval/rag_answer_service.py
@@ -1,8 +1,9 @@
 import logging
+from collections.abc import Awaitable, Callable
 
 from app.services.gemini import GeminiService
 from app.services.RAG.client import embed_query
-from app.services.RAG.shared.vector_search import MongoVectorSearchReader
+from app.services.RAG.shared.vector_search import ChunkHits, MongoVectorSearchReader
 
 from .errors import RagNoHitsError
 from .retriever import search_similar_chunks
@@ -15,15 +16,21 @@ class RagAnswerService:
         self,
         gemini_service: GeminiService,
         vector_search_reader: MongoVectorSearchReader,
+        embed_query_fn: Callable[[str], Awaitable[list[float]]] = embed_query,
+        search_similar_chunks_fn: Callable[
+            [list[float], MongoVectorSearchReader], Awaitable[ChunkHits]
+        ] = search_similar_chunks,
     ) -> None:
         self.gemini_service = gemini_service
         self.vector_search_reader = vector_search_reader
+        self.embed_query_fn = embed_query_fn
+        self.search_similar_chunks_fn = search_similar_chunks_fn
 
     async def answer(self, user_text: str) -> str:
-        query_vec = await embed_query(user_text)
-        hits = await search_similar_chunks(
+        query_vec = await self.embed_query_fn(user_text)
+        hits = await self.search_similar_chunks_fn(
             query_vec,
-            reader=self.vector_search_reader,
+            self.vector_search_reader,
         )
 
         context_lines = []

--- a/app/services/gemini/client/service.py
+++ b/app/services/gemini/client/service.py
@@ -1,5 +1,7 @@
 import httpx
-from app.core.config import settings
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
 from app.services.gemini.shared.errors import (
     GeminiHttpError,
     GeminiNetworkError,
@@ -14,9 +16,22 @@ logger = logging.getLogger(__name__)
 
 
 class GeminiService:
-    def __init__(self):
-        self.api_key = settings.GEMINI_API_KEY
-        self.model_name = settings.MODEL_NAME
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model_name: str,
+        http_client_factory: Callable[
+            [float], AbstractAsyncContextManager[httpx.AsyncClient]
+        ] | None = None,
+    ):
+        self.api_key = api_key
+        self.model_name = model_name
+        self.http_client_factory = (
+            http_client_factory
+            if http_client_factory is not None
+            else (lambda timeout: httpx.AsyncClient(timeout=timeout))
+        )
         self.api_url = (
             f"https://generativelanguage.googleapis.com/v1beta/models/"
             f"{self.model_name}:generateContent"
@@ -34,7 +49,7 @@ class GeminiService:
     async def generate_content(self, payload: dict, timeout: float = 300.0) -> dict:
         """呼叫 Gemini generateContent 並回傳原始 JSON。"""
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with self.http_client_factory(timeout) as client:
                 response = await client.post(
                     self.api_url,
                     params={"key": self.api_key},

--- a/app/services/media/mutimedia_processor.py
+++ b/app/services/media/mutimedia_processor.py
@@ -47,7 +47,10 @@ class MediaProcessorService:
     """Handle incoming LINE text and send replies based on Gemini tool output."""
 
     def __init__(self):
-        self.gemini_service = GeminiService()
+        self.gemini_service = GeminiService(
+            api_key=settings.GEMINI_API_KEY,
+            model_name=settings.MODEL_NAME,
+        )
         logger.info("MediaProcessorService initialized with Gemini AI")
 
     async def process_media(

--- a/tests/unit/orchestration/test_response_orchestrator.py
+++ b/tests/unit/orchestration/test_response_orchestrator.py
@@ -5,7 +5,7 @@ from app.services.gemini import GeminiResult
 from app.services.RAG.retrieval import RagNoHitsError
 from app.orchestration.response_orchestrator import ResponseOrchestrator
 
-
+#這邊是在測說我的流程有沒有邏輯錯誤
 @pytest.mark.asyncio
 async def test_route_response_text_uses_gemini_directly():
     gemini_service = MagicMock()

--- a/tests/unit/services/RAG/retrieval/test_rag_answer_service.py
+++ b/tests/unit/services/RAG/retrieval/test_rag_answer_service.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 import sys
 import types
 
@@ -29,23 +29,26 @@ from app.services.RAG.retrieval.rag_answer_service import RagAnswerService
 async def test_answer_uses_hits_to_build_rag_prompt():
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock(return_value=GeminiResult(text="RAG 回覆"))
-    svc = RagAnswerService(gemini_service=gemini_service, vector_search_reader=MagicMock())
-
-    with patch(
-        "app.services.RAG.retrieval.rag_answer_service.embed_query",
-        new_callable=AsyncMock,
-        return_value=[0.1, 0.2],
-    ), patch(
-        "app.services.RAG.retrieval.rag_answer_service.search_similar_chunks",
-        new_callable=AsyncMock,
+    embed_query_fn = AsyncMock(return_value=[0.1, 0.2])
+    search_similar_chunks_fn = AsyncMock(
         return_value=[
             {"id": "1", "text": "高血壓建議低鈉飲食", "score": 0.9},
             {"id": "2", "text": "規律量血壓", "score": 0.8},
-        ],
-    ):
-        result = await svc.answer("我有高血壓要注意什麼")
+        ]
+    )
+    vector_search_reader = MagicMock()
+    svc = RagAnswerService(
+        gemini_service=gemini_service,
+        vector_search_reader=vector_search_reader,
+        embed_query_fn=embed_query_fn,
+        search_similar_chunks_fn=search_similar_chunks_fn,
+    )
+    result = await svc.answer("我有高血壓要注意什麼")
 
     assert result == "RAG 回覆"
+    search_similar_chunks_fn.assert_awaited_once_with(
+        [0.1, 0.2], vector_search_reader
+    )
     prompt = gemini_service.generate_response.await_args.args[0]
     assert "高血壓建議低鈉飲食" in prompt
     assert "規律量血壓" in prompt
@@ -60,20 +63,19 @@ async def test_answer_uses_hits_to_build_rag_prompt():
 async def test_answer_uses_default_message_when_model_returns_empty_text(model_text):
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock(return_value=GeminiResult(text=model_text))
-    svc = RagAnswerService(gemini_service=gemini_service, vector_search_reader=MagicMock())
-
-    with patch(
-        "app.services.RAG.retrieval.rag_answer_service.embed_query",
-        new_callable=AsyncMock,
-        return_value=[0.1, 0.2],
-    ), patch(
-        "app.services.RAG.retrieval.rag_answer_service.search_similar_chunks",
-        new_callable=AsyncMock,
+    embed_query_fn = AsyncMock(return_value=[0.1, 0.2])
+    search_similar_chunks_fn = AsyncMock(
         return_value=[
             {"id": "1", "text": "高血壓建議低鈉飲食", "score": 0.9},
-        ],
-    ):
-        result = await svc.answer("我有高血壓要注意什麼")
+        ]
+    )
+    svc = RagAnswerService(
+        gemini_service=gemini_service,
+        vector_search_reader=MagicMock(),
+        embed_query_fn=embed_query_fn,
+        search_similar_chunks_fn=search_similar_chunks_fn,
+    )
+    result = await svc.answer("我有高血壓要注意什麼")
 
     assert result == "抱歉，我目前找不到相關資料，請稍後再試。"
 
@@ -82,19 +84,16 @@ async def test_answer_uses_default_message_when_model_returns_empty_text(model_t
 async def test_answer_raises_rag_no_hits_when_no_hits():
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock()
-    svc = RagAnswerService(gemini_service=gemini_service, vector_search_reader=MagicMock())
-
-    with patch(
-        "app.services.RAG.retrieval.rag_answer_service.embed_query",
-        new_callable=AsyncMock,
-        return_value=[0.1, 0.2],
-    ), patch(
-        "app.services.RAG.retrieval.rag_answer_service.search_similar_chunks",
-        new_callable=AsyncMock,
-        return_value=[],
-    ):
-        with pytest.raises(RagNoHitsError):
-            await svc.answer("我有高血壓要注意什麼")
+    embed_query_fn = AsyncMock(return_value=[0.1, 0.2])
+    search_similar_chunks_fn = AsyncMock(return_value=[])
+    svc = RagAnswerService(
+        gemini_service=gemini_service,
+        vector_search_reader=MagicMock(),
+        embed_query_fn=embed_query_fn,
+        search_similar_chunks_fn=search_similar_chunks_fn,
+    )
+    with pytest.raises(RagNoHitsError):
+        await svc.answer("我有高血壓要注意什麼")
 
     gemini_service.generate_response.assert_not_awaited()
 
@@ -103,31 +102,29 @@ async def test_answer_raises_rag_no_hits_when_no_hits():
 async def test_answer_raises_when_embed_query_fails():
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock()
-    svc = RagAnswerService(gemini_service=gemini_service, vector_search_reader=MagicMock())
+    embed_query_fn = AsyncMock(side_effect=RuntimeError("embed failed"))
+    svc = RagAnswerService(
+        gemini_service=gemini_service,
+        vector_search_reader=MagicMock(),
+        embed_query_fn=embed_query_fn,
+        search_similar_chunks_fn=AsyncMock(),
+    )
 
-    with patch(
-        "app.services.RAG.retrieval.rag_answer_service.embed_query",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("embed failed"),
-    ):
-        with pytest.raises(RuntimeError, match="embed failed"):
-            await svc.answer("我有高血壓要注意什麼")
+    with pytest.raises(RuntimeError, match="embed failed"):
+        await svc.answer("我有高血壓要注意什麼")
 
 
 @pytest.mark.asyncio
 async def test_answer_raises_when_search_fails():
     gemini_service = MagicMock()
     gemini_service.generate_response = AsyncMock()
-    svc = RagAnswerService(gemini_service=gemini_service, vector_search_reader=MagicMock())
-
-    with patch(
-        "app.services.RAG.retrieval.rag_answer_service.embed_query",
-        new_callable=AsyncMock,
-        return_value=[0.1, 0.2],
-    ), patch(
-        "app.services.RAG.retrieval.rag_answer_service.search_similar_chunks",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("search failed"),
-    ):
-        with pytest.raises(RuntimeError, match="search failed"):
-            await svc.answer("我有高血壓要注意什麼")
+    embed_query_fn = AsyncMock(return_value=[0.1, 0.2])
+    search_similar_chunks_fn = AsyncMock(side_effect=RuntimeError("search failed"))
+    svc = RagAnswerService(
+        gemini_service=gemini_service,
+        vector_search_reader=MagicMock(),
+        embed_query_fn=embed_query_fn,
+        search_similar_chunks_fn=search_similar_chunks_fn,
+    )
+    with pytest.raises(RuntimeError, match="search failed"):
+        await svc.answer("我有高血壓要注意什麼")

--- a/tests/unit/services/gemini/test_gemini_service.py
+++ b/tests/unit/services/gemini/test_gemini_service.py
@@ -1,59 +1,60 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-from app.services.gemini import GeminiService, GeminiHttpError
+from app.services.gemini import GeminiHttpError, GeminiService
+
+
+class _FakeClientContext:
+    def __init__(self, client):
+        self._client = client
+
+    async def __aenter__(self):
+        return self._client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 @pytest.fixture
-def mock_settings():
-    with patch("app.services.gemini.client.service.settings") as m:
-        m.GEMINI_API_KEY = "test_key"
-        m.MODEL_NAME = "gemini-2.0-flash"
-        yield m
+def service_factory():
+    def _build(response):
+        post = AsyncMock(return_value=response)
+        client = MagicMock()
+        client.post = post
+        svc = GeminiService(
+            api_key="test_key",
+            model_name="gemini-2.0-flash",
+            http_client_factory=lambda timeout: _FakeClientContext(client),
+        )
+        return svc, post
 
-
-@pytest.fixture
-def mock_http_client():
-    with patch("app.services.gemini.client.service.httpx.AsyncClient") as mock_ac:
-        mock_ac.return_value.__aexit__ = AsyncMock(return_value=None)
-
-        def configure(response):
-            post = AsyncMock(return_value=response)
-            client_instance = MagicMock()
-            client_instance.post = post
-            mock_ac.return_value.__aenter__ = AsyncMock(return_value=client_instance)
-            return post
-
-        yield configure
+    return _build
 
 
 @pytest.mark.asyncio
-async def test_generate_response_returns_text_on_success(
-    mock_settings, mock_http_client
-):
-    # 準備假 response：200 成功
+async def test_generate_response_returns_text_on_success(service_factory):
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = {
         "candidates": [{"content": {"parts": [{"text": "AI 回覆內容"}]}}]
     }
-    post = mock_http_client(response)
+    svc, post = service_factory(response)
 
-    result = await GeminiService().generate_response("你好")
+    result = await svc.generate_response("你好")
 
     assert result.text == "AI 回覆內容"
-    assert post.called  # 確定 generate_response 有去呼叫 post
+    assert post.called
 
 
 @pytest.mark.asyncio
 async def test_generate_response_returns_validation_error_without_api_call(
-    mock_settings, mock_http_client
+    service_factory,
 ):
     response = MagicMock()
     response.status_code = 200
-    post = mock_http_client(response)
+    svc, post = service_factory(response)
 
-    result = await GeminiService().generate_response("   ")
+    result = await svc.generate_response("   ")
 
     assert result.text == "請輸入訊息內容，不能為空白。"
     assert result.is_function_call is False
@@ -61,9 +62,7 @@ async def test_generate_response_returns_validation_error_without_api_call(
 
 
 @pytest.mark.asyncio
-async def test_generate_response_returns_function_call_from_model(
-    mock_settings, mock_http_client
-):
+async def test_generate_response_returns_function_call_from_model(service_factory):
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = {
@@ -82,9 +81,9 @@ async def test_generate_response_returns_function_call_from_model(
             }
         ]
     }
-    mock_http_client(response)
+    svc, _ = service_factory(response)
 
-    result = await GeminiService().generate_response("附近哪裡有醫院")
+    result = await svc.generate_response("附近哪裡有醫院")
 
     assert result.is_function_call is True
     assert result.function_name == "request_location"
@@ -92,16 +91,13 @@ async def test_generate_response_returns_function_call_from_model(
 
 
 @pytest.mark.asyncio
-async def test_generate_response_raises_value_error_on_4xx(
-    mock_settings, mock_http_client
-):
-    # 準備假 response：429 配額超限
+async def test_generate_response_raises_http_error_on_4xx(service_factory):
     response = MagicMock()
     response.status_code = 429
     response.text = "quota exceeded"
-    mock_http_client(response)
+    svc, _ = service_factory(response)
 
     with pytest.raises(GeminiHttpError) as exc_info:
-        await GeminiService().generate_response("hi")
+        await svc.generate_response("hi")
 
     assert "配額" in str(exc_info.value) or "429" in str(exc_info.value)


### PR DESCRIPTION
- Require GeminiService api_key/model_name via constructor injection and keep injectable http client factory for tests.
- Wire GeminiService construction in dependencies and media processor via explicit settings-based injection.
- Make RagAnswerService inject both embed_query and search function to remove hidden module-level dependencies.
- Update unit tests to use injected AsyncMock dependencies instead of module patch paths.

Made-with: Cursor