### PR TITLE
refactor(line-di): inject messaging client adapter into line service

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -8,6 +8,9 @@ from app.services.guardrail import GuardrailService
 from app.services.RAG.client import embed_query
 from app.services.RAG.retrieval import RagAnswerService, search_similar_chunks
 from app.services.line.message_service import LineMessageService
+from app.services.line.messaging_client import LineMessagingClient
+from app.services.line.token_manager import line_token_manager
+from app.services.medical.medical_service import medical_service
 from app.services.RAG.shared.vector_search import (
     MongoVectorSearchReader,
     VectorSearchConfig,
@@ -33,8 +36,12 @@ _response_orchestrator = ResponseOrchestrator(
     guardrail_service=_guardrail_service,
     rag_answer_service=_rag_answer_service,
 )
+
 _line_message_service = LineMessageService(
     response_orchestrator=_response_orchestrator,
+    token_provider=line_token_manager,
+    medical_service=medical_service,
+    line_messaging_client=LineMessagingClient(),
 )
 
 

--- a/app/services/line/__init__.py
+++ b/app/services/line/__init__.py
@@ -3,6 +3,7 @@
 
 from typing import TYPE_CHECKING, Any
 
+from app.services.line.messaging_client import LineMessagingClient
 from app.services.line.token_manager import LineTokenManager, line_token_manager
 
 if TYPE_CHECKING:
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LineMessageService",
+    "LineMessagingClient",
     "LineTokenManager",
     "line_token_manager",
     "LineEventContext",

--- a/app/services/line/message_service.py
+++ b/app/services/line/message_service.py
@@ -1,8 +1,5 @@
-from typing import Optional
+from typing import Optional, Protocol
 from linebot.v3.messaging import (
-    Configuration,
-    ApiClient,
-    MessagingApi,
     ReplyMessageRequest,
     TextMessage,
     QuickReply,
@@ -10,19 +7,35 @@ from linebot.v3.messaging import (
     LocationAction,
 )
 from app.orchestration import ResponseOrchestrator
-from app.services.line.token_manager import line_token_manager
-from app.services.medical.medical_service import medical_service
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+class TokenProvider(Protocol):
+    def get_token(self) -> str: ...
+
+
+class MedicalServiceLike(Protocol):
+    def request_location(self, user_id: str) -> dict: ...
+
+
+class LineMessagingClientLike(Protocol):
+    def reply_message(self, access_token: str, request: ReplyMessageRequest) -> None: ...
 
 
 class LineMessageService:
     def __init__(
         self,
         response_orchestrator: ResponseOrchestrator,
+        token_provider: TokenProvider,
+        medical_service: MedicalServiceLike,
+        line_messaging_client: LineMessagingClientLike,
     ):
         self.response_orchestrator = response_orchestrator
+        self.token_provider = token_provider
+        self.medical_service = medical_service
+        self.line_messaging_client = line_messaging_client
         logger.info("LineMessageService initialized with Gemini AI")
 
     async def process_and_reply(
@@ -57,16 +70,14 @@ class LineMessageService:
         self, reply_token: str, message_text: str, user_id: Optional[str] = None
     ) -> bool:
         try:
-            access_token = line_token_manager.get_token()
-            line_config = Configuration(access_token=access_token)
-            with ApiClient(line_config) as api_client:
-                line_bot_api = MessagingApi(api_client)
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=reply_token,
-                        messages=[TextMessage(text=message_text)],
-                    )
-                )
+            access_token = self.token_provider.get_token()
+            self.line_messaging_client.reply_message(
+                access_token,
+                ReplyMessageRequest(
+                    reply_token=reply_token,
+                    messages=[TextMessage(text=message_text)],
+                ),
+            )
 
             logger.info(f"Message sent to LINE for user {user_id}")
             return True
@@ -83,28 +94,24 @@ class LineMessageService:
         self, reply_token: str, user_id: Optional[str] = None
     ) -> bool:
         try:
-            medical_service.request_location(user_id)
-            access_token = line_token_manager.get_token()
-            line_config = Configuration(access_token=access_token)
-            with ApiClient(line_config) as api_client:
-                line_bot_api = MessagingApi(api_client)
-                line_bot_api.reply_message(
-                    ReplyMessageRequest(
-                        reply_token=reply_token,
-                        messages=[
-                            TextMessage(
-                                text="請傳送您目前的位置資訊，我將為您尋找附近的醫療院所 🏥",
-                                quick_reply=QuickReply(
-                                    items=[
-                                        QuickReplyItem(
-                                            action=LocationAction(label="傳送位置資訊")
-                                        )
-                                    ]
-                                ),
-                            )
-                        ],
+            self.medical_service.request_location(user_id)
+            access_token = self.token_provider.get_token()
+            request = ReplyMessageRequest(
+                reply_token=reply_token,
+                messages=[
+                    TextMessage(
+                        text="請傳送您目前的位置資訊，我將為您尋找附近的醫療院所 ",
+                        quick_reply=QuickReply(
+                            items=[
+                                QuickReplyItem(
+                                    action=LocationAction(label="傳送位置資訊")
+                                )
+                            ]
+                        ),
                     )
-                )
+                ],
+            )
+            self.line_messaging_client.reply_message(access_token, request)
             logger.info(f"Location quick reply sent to user {user_id}")
             return True
 

--- a/app/services/line/messaging_client.py
+++ b/app/services/line/messaging_client.py
@@ -1,0 +1,12 @@
+from linebot.v3.messaging import ApiClient, Configuration, MessagingApi, ReplyMessageRequest
+#先匯入line的 sdk
+
+class LineMessagingClient: # 讓 message_service 不需要直接呼叫 line的 sdk
+    def reply_message(self, access_token: str, request: ReplyMessageRequest) -> None:
+        line_config = Configuration(access_token=access_token) #把 token 塞進 sdk config
+        with ApiClient(line_config) as api_client: #建立 line api client
+            line_bot_api = MessagingApi(api_client) #建立物件
+            line_bot_api.reply_message(request)
+
+#整個 client 只管 line sdk 怎麼算出去
+# 在 message_service 管要回啥

--- a/tests/unit/services/line/test_message_service.py
+++ b/tests/unit/services/line/test_message_service.py
@@ -21,7 +21,12 @@ async def test_process_success(mock_send_reply):
     mock_response_orchestrator.orchestrate_response = AsyncMock(
         return_value=GeminiResult(text="AI 回覆")
     )
-    svc = LineMessageService(response_orchestrator=mock_response_orchestrator)
+    svc = LineMessageService(
+        response_orchestrator=mock_response_orchestrator,
+        token_provider=MagicMock(),
+        medical_service=MagicMock(),
+        line_messaging_client=MagicMock(),
+    )
     ok = await svc.process_and_reply("你好", "reply_token_xxx")
 
     assert ok is True
@@ -41,7 +46,12 @@ async def test_process_function_call_request_location(mock_send_reply):
         mock_response_orchestrator.orchestrate_response = AsyncMock(
             return_value=GeminiResult(function_name="request_location")
         )
-        svc = LineMessageService(response_orchestrator=mock_response_orchestrator)
+        svc = LineMessageService(
+            response_orchestrator=mock_response_orchestrator,
+            token_provider=MagicMock(),
+            medical_service=MagicMock(),
+            line_messaging_client=MagicMock(),
+        )
         ok = await svc.process_and_reply(
             "附近有醫院嗎", "reply_token_xxx", user_id="U123"
         )
@@ -56,7 +66,12 @@ async def test_process_fallback_on_value_error(mock_send_reply):
     # router 發生錯誤時，應送出 fallback 訊息
     mock_response_orchestrator = MagicMock()
     mock_response_orchestrator.orchestrate_response = AsyncMock(side_effect=ValueError("API 錯誤"))
-    svc = LineMessageService(response_orchestrator=mock_response_orchestrator)
+    svc = LineMessageService(
+        response_orchestrator=mock_response_orchestrator,
+        token_provider=MagicMock(),
+        medical_service=MagicMock(),
+        line_messaging_client=MagicMock(),
+    )
     ok = await svc.process_and_reply("hi", "reply_token_xxx")
 
     assert ok is False


### PR DESCRIPTION
- Keep LineMessageService focused on orchestration and message composition.
- Move LINE SDK reply wiring into a dedicated LineMessagingClient adapter.
- Inject token provider, medical service, and messaging client from dependencies.
- Update line message service unit tests to pass explicit injected mocks.

Made-with: Cursor