### PR TITLE
新增資料來源，並明確標出是rag 來源

### DIFF
--- a/app/application/line/event_handler.py
+++ b/app/application/line/event_handler.py
@@ -179,3 +179,4 @@ class LineEventHandler:
             error_message = "抱歉，處理您的訊息時發生錯誤，請稍後再試"
             await self._line_message_service.send_line_reply(reply_token, error_message, user_id)
             return False
+

--- a/app/application/rag/services/rag_answer_service.py
+++ b/app/application/rag/services/rag_answer_service.py
@@ -66,11 +66,45 @@ class RagAnswerService:
             raise RagNoHitsError(user_text)
 
         rag_prompt = (
-            "請根據以下檢索到的醫療知識內容回答使用者問題。"
+            "請根據以下 RAG 提供的醫療知識內容回答使用者問題。"
+            "回覆中不要使用「根據檢索內容」這類字眼，改用「根據 RAG 資訊」等說法。"
+            "請使用一般純文字，不要使用 Markdown 格式符號。"
             "若內容不足，請明確說明不知道，勿捏造。\n\n"
             f"使用者問題：{user_text}\n\n"
-            "檢索內容：\n"
+            "RAG 內容：\n"
             f"{chr(10).join(context_lines)}"
         )
         rag_result = await self.gemini_service.generate_response(rag_prompt)
-        return rag_result.text or "抱歉，我目前找不到相關資料，請稍後再試。"
+        answer_text = rag_result.text or "抱歉，我目前找不到相關資料，請稍後再試。"
+        return self._append_sources(answer_text, hits)
+
+    @staticmethod
+    def _append_sources(answer_text: str, hits: ChunkHits) -> str:
+        max_sources = 3
+        source_lines: list[str] = []
+        seen: set[tuple[str, str]] = set()
+
+        sorted_hits = sorted(
+            hits,
+            key=lambda h: h.get("score") if h.get("score") is not None else float("-inf"),
+            reverse=True,
+        )
+
+        for hit in sorted_hits:
+            source_name = (hit.get("source_name") or "").strip()
+            url = (hit.get("url") or "").strip()
+            if not source_name or not url:
+                continue
+
+            key = (source_name, url)
+            if key in seen:
+                continue
+            seen.add(key)
+            source_lines.append(f"- {source_name}：{url}")
+            if len(source_lines) >= max_sources:
+                break
+
+        if not source_lines:
+            return answer_text
+
+        return f"{answer_text}\n\n資料來源：\n" + "\n".join(source_lines)

--- a/app/infrastructure/vector_search/mapping.py
+++ b/app/infrastructure/vector_search/mapping.py
@@ -12,4 +12,6 @@ def mongo_document_to_chunk_hit(
         "id": str(doc.get("_id")),
         "text": doc.get(text_field),
         "score": doc.get("score"),
+        "source_name": doc.get("source_name"),
+        "url": doc.get("url"),
     }

--- a/app/infrastructure/vector_search/pipeline.py
+++ b/app/infrastructure/vector_search/pipeline.py
@@ -24,6 +24,8 @@ def build_vector_search_pipeline(
             "$project": {
                 config.text_field: 1,
                 "_id": 1,
+                "source_name": 1,
+                "url": 1,
                 "score": {"$meta": "vectorSearchScore"},
             }
         },

--- a/app/infrastructure/vector_search/types.py
+++ b/app/infrastructure/vector_search/types.py
@@ -5,6 +5,8 @@ class ChunkHit(TypedDict):
     id: str
     text: Optional[str]
     score: Optional[float]
+    source_name: Optional[str]
+    url: Optional[str]
 
 
 ChunkHits = List[ChunkHit]

--- a/tests/unit/application/rag/services/test_rag_answer_service.py
+++ b/tests/unit/application/rag/services/test_rag_answer_service.py
@@ -34,8 +34,20 @@ async def test_answer_uses_hits_to_build_rag_prompt():
     similar_chunk_searcher = MagicMock()
     similar_chunk_searcher.search_similar_chunks = AsyncMock(
         return_value=[
-            {"id": "1", "text": "高血壓建議低鈉飲食", "score": 0.9},
-            {"id": "2", "text": "規律量血壓", "score": 0.8},
+            {
+                "id": "1",
+                "text": "高血壓建議低鈉飲食",
+                "score": 0.9,
+                "source_name": "衛福部闢謠網站",
+                "url": "https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=5020&pid=19922",
+            },
+            {
+                "id": "2",
+                "text": "規律量血壓",
+                "score": 0.8,
+                "source_name": "衛福部闢謠網站",
+                "url": "https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=5020&pid=19922",
+            },
         ]
     )
     vector_search_reader = MagicMock()
@@ -47,7 +59,9 @@ async def test_answer_uses_hits_to_build_rag_prompt():
     )
     result = await svc.answer("我有高血壓要注意什麼")
 
-    assert result == "RAG 回覆"
+    assert "RAG 回覆" in result
+    assert "資料來源：" in result
+    assert "衛福部闢謠網站" in result
     similar_chunk_searcher.search_similar_chunks.assert_awaited_once_with(
         [0.1, 0.2], vector_search_reader
     )
@@ -70,7 +84,13 @@ async def test_answer_uses_default_message_when_model_returns_empty_text(model_t
     similar_chunk_searcher = MagicMock()
     similar_chunk_searcher.search_similar_chunks = AsyncMock(
         return_value=[
-            {"id": "1", "text": "高血壓建議低鈉飲食", "score": 0.9},
+            {
+                "id": "1",
+                "text": "高血壓建議低鈉飲食",
+                "score": 0.9,
+                "source_name": None,
+                "url": None,
+            },
         ]
     )
     svc = RagAnswerService(

--- a/tests/unit/infrastructure/vector_search/test_config_mapping_pipeline.py
+++ b/tests/unit/infrastructure/vector_search/test_config_mapping_pipeline.py
@@ -5,7 +5,13 @@ from app.infrastructure.vector_search.pipeline import build_vector_search_pipeli
 
 def test_mongo_document_to_chunk_hit_handles_missing_fields():
     hit = mongo_document_to_chunk_hit({}, text_field="chunk_text")
-    assert hit == {"id": "None", "text": None, "score": None}
+    assert hit == {
+        "id": "None",
+        "text": None,
+        "score": None,
+        "source_name": None,
+        "url": None,
+    }
 
 
 def test_build_vector_search_pipeline_contains_expected_projection():
@@ -27,6 +33,8 @@ def test_build_vector_search_pipeline_contains_expected_projection():
     assert pipeline[0]["$vectorSearch"]["limit"] == 5
     assert pipeline[0]["$vectorSearch"]["numCandidates"] == 100
     assert pipeline[1]["$project"]["chunk_text"] == 1
+    assert pipeline[1]["$project"]["source_name"] == 1
+    assert pipeline[1]["$project"]["url"] == 1
     assert pipeline[1]["$project"]["score"] == {"$meta": "vectorSearchScore"}
 
 

--- a/tests/unit/infrastructure/vector_search/test_reader.py
+++ b/tests/unit/infrastructure/vector_search/test_reader.py
@@ -65,8 +65,20 @@ async def test_search_by_embedding_maps_docs_to_hits():
         hits = await reader.search_by_embedding(query_embedding=[0.1, 0.2], k=2)
 
     assert hits == [
-        {"id": "123", "text": "A", "score": 0.9},
-        {"id": "b", "text": "B", "score": None},
+        {
+            "id": "123",
+            "text": "A",
+            "score": 0.9,
+            "source_name": None,
+            "url": None,
+        },
+        {
+            "id": "b",
+            "text": "B",
+            "score": None,
+            "source_name": None,
+            "url": None,
+        },
     ]
     fake_collection.aggregate.assert_called_once_with([{"$vectorSearch": {}}])
     mock_pipeline.assert_called_once()


### PR DESCRIPTION
Expose source_name and url in vector hits, append top-3 deduplicated sources to RAG answers, and align prompt/test expectations for LINE-friendly plain-text output.

Made-with: Cursor