### PR TITLE
test: 將前端 i18n 與 settings 測試描述改為中文

### DIFF
--- a/frontend/liff-app/src/tests/i18n.test.ts
+++ b/frontend/liff-app/src/tests/i18n.test.ts
@@ -1,26 +1,29 @@
 import { getInitialLanguage, isSupportedLanguage } from '../i18n';
-
-describe('i18n', () => {
+//先讀 localStorage
+//parse JSON
+//檢查 language 是否支援
+//失敗一律 fallback zh-TW
+describe('多語系初始化邏輯', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it('returns language from localStorage when supported', () => {
+  it('當 localStorage 是支援語言時，應回傳該語言', () => {
     localStorage.setItem('care-settings', JSON.stringify({ language: 'vi' }));
     expect(getInitialLanguage('care-settings')).toBe('vi');
   });
-
-  it('falls back to zh-TW when language is unsupported', () => {
+//localStorage 裡有值，但語言不支援
+  it('當語言不支援時，應回退到 zh-TW', () => {
     localStorage.setItem('care-settings', JSON.stringify({ language: 'fr' }));
     expect(getInitialLanguage('care-settings')).toBe('zh-TW');
   });
-
-  it('falls back to zh-TW when storage is malformed', () => {
+//localStorage 裡有值，但語言不支援
+  it('當 localStorage 格式損壞時，應回退到 zh-TW', () => {
     localStorage.setItem('care-settings', '{broken-json');
     expect(getInitialLanguage('care-settings')).toBe('zh-TW');
   });
-
-  it('checks supported language values', () => {
+//ocalStorage 壞掉，JSON 解析失敗
+  it('應正確判斷語言是否為支援清單', () => {
     expect(isSupportedLanguage('en')).toBe(true);
     expect(isSupportedLanguage('zh-TW')).toBe(true);
     expect(isSupportedLanguage('fr')).toBe(false);

--- a/frontend/liff-app/src/tests/settings.test.tsx
+++ b/frontend/liff-app/src/tests/settings.test.tsx
@@ -11,23 +11,23 @@ function renderSettings(initialLanguage = 'zh-TW' as const) {
   );
 }
 
-describe('Settings language behavior', () => {
+describe('設定頁語言行為', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it('updates localStorage and UI language when selection changes', () => {
+  it('切換語言後，應同步更新 localStorage 與畫面語言', () => {
     renderSettings();
 
     const select = screen.getByLabelText('顯示語言') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'en' } });
-
+//使用者改語言 → 有沒有存進 localStorage
     const saved = JSON.parse(localStorage.getItem('care-settings') || '{}');
     expect(saved.language).toBe('en');
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
   });
-
-  it('keeps selected language after re-mount', () => {
+//UI 有沒有真的變英文
+  it('重新掛載後，應保留先前選擇的語言', () => {
     localStorage.setItem(
       'care-settings',
       JSON.stringify({


### PR DESCRIPTION
更新兩個前端測試檔的 describe/it 文字為中文，讓測試意圖更直覺易讀，並保留既有驗證邏輯不變。

Made-with: Cursor