### PR TITLE
使用者個人健康資料頁新增與修改流程

### DIFF
--- a/app/application/liff/auth_service.py
+++ b/app/application/liff/auth_service.py
@@ -36,10 +36,14 @@ class LiffAuthApplicationService:
             )
         except requests.RequestException as exc:
             logger.error(f"驗證 LIFF ID token 時 LINE API 連線失敗: {exc}")
-            raise HTTPException(status_code=502, detail="Failed to verify id_token") from exc
+            raise HTTPException(
+                status_code=502, detail="Failed to verify id_token"
+            ) from exc
         except ValueError as exc:
             logger.warning(f"LIFF ID token 驗證失敗: {exc}")
-            raise HTTPException(status_code=401, detail="Invalid LIFF id_token") from exc
+            raise HTTPException(
+                status_code=401, detail="Invalid LIFF id_token"
+            ) from exc
 
         line_user_id = verify_payload.get("sub")
         if not line_user_id:

--- a/app/application/users/profile_service.py
+++ b/app/application/users/profile_service.py
@@ -1,8 +1,0 @@
-from app.repositories.user_profile_repository import UserProfileRepository
-
-class ProfileService:
-    def __init__(self, repo: UserProfileRepository) -> None:
-        self._repo = repo
-
-    async def upsert_profile(self, line_id: str, payload: dict) -> bool:
-        return await self._repo.upsert_profile(line_id, payload)

--- a/app/core/cors.py
+++ b/app/core/cors.py
@@ -21,6 +21,7 @@ def get_cors_origins() -> List[str]:
     return [
         "http://localhost:5173",
         "http://127.0.0.1:5173",
+        "https://supersagacious-alysha-unadjacent.ngrok-free.dev",
     ]
 
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,5 +1,9 @@
 #  小註解：不從原有程式new物件，依賴dependency injection注入物件 那dependencies 就叫做 container
+from dataclasses import dataclass
 import os
+
+import jwt  # type: ignore[import-not-found]
+from fastapi import Header, HTTPException
 
 from app.core.config import settings
 from app.infrastructure.gemini import GeminiService
@@ -18,6 +22,9 @@ from app.db.mongodb import MongoDBManager
 from app.services.users.user_profile_service import UserProfileService
 from app.repositories.user_profile_repository import UserProfileRepository
 from app.application.family.family_tree_service import FamilyTreeService
+from app.application.liff.auth_service import LiffAuthApplicationService
+from app.services.liff.jwt_service import AppJwtService
+from app.services.liff.line_id_token_service import LineIdTokenService
 
 _mongodb_url = os.getenv("MONGODB_URL")
 MongoDBManager.configure(_mongodb_url or settings.MONGODB_URI)
@@ -57,11 +64,23 @@ _line_event_handler = LineEventHandler(
 )
 
 # 使用者資料相關的依賴注入
-_user_profile_repository = UserProfileRepository()
-_user_profile_service = UserProfileService(repo=_user_profile_repository)
+_profile_repository = UserProfileRepository()
+_profile_service = UserProfileService(repo=_profile_repository)
 
 # Family Tree 服務
 _family_tree_service = FamilyTreeService()
+
+# LIFF Auth 服務
+_line_id_token_service = LineIdTokenService()
+_app_jwt_service = AppJwtService(
+    secret=settings.AUTH_JWT_SECRET,
+    algorithm=settings.AUTH_JWT_ALGORITHM,
+    expires_minutes=settings.AUTH_JWT_EXPIRES_MINUTES,
+)
+_liff_auth_application_service = LiffAuthApplicationService(
+    line_id_token_service=_line_id_token_service,
+    jwt_service=_app_jwt_service,
+)
 
 
 def get_mongodb_url() -> str:
@@ -108,8 +127,39 @@ def get_vector_search_reader() -> MongoVectorSearchReader:
 
 
 def get_user_profile_service() -> UserProfileService:
-    return _user_profile_service
+    return _profile_service
 
 
 def get_family_tree_service() -> FamilyTreeService:
     return _family_tree_service
+
+
+def get_liff_auth_application_service() -> LiffAuthApplicationService:
+    return _liff_auth_application_service
+
+
+@dataclass
+class CurrentUser:
+    line_user_id: str
+
+
+def get_current_user(authorization: str | None = Header(default=None)) -> CurrentUser:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        raise HTTPException(
+            status_code=401, detail="Invalid Authorization header format"
+        )
+
+    try:
+        line_user_id = _app_jwt_service.decode_user_id(token.strip())
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+
+    return CurrentUser(line_user_id=line_user_id)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,9 +1,5 @@
 #  小註解：不從原有程式new物件，依賴dependency injection注入物件 那dependencies 就叫做 container
-from dataclasses import dataclass
 import os
-
-import jwt  # type: ignore[import-not-found]
-from fastapi import Header, HTTPException
 
 from app.core.config import settings
 from app.infrastructure.gemini import GeminiService
@@ -19,12 +15,10 @@ from app.infrastructure.vector_search import (
     VectorSearchConfig,
 )
 from app.db.mongodb import MongoDBManager
-from app.application.users.profile_service import ProfileService
+from app.services.users.user_profile_service import UserProfileService
 from app.repositories.user_profile_repository import UserProfileRepository
 from app.application.family.family_tree_service import FamilyTreeService
-from app.application.liff.auth_service import LiffAuthApplicationService
-from app.services.liff.jwt_service import AppJwtService
-from app.services.liff.line_id_token_service import LineIdTokenService
+
 _mongodb_url = os.getenv("MONGODB_URL")
 MongoDBManager.configure(_mongodb_url or settings.MONGODB_URI)
 
@@ -63,23 +57,11 @@ _line_event_handler = LineEventHandler(
 )
 
 # 使用者資料相關的依賴注入
-_profile_repository = UserProfileRepository()
-_profile_service = ProfileService(repo=_profile_repository)
+_user_profile_repository = UserProfileRepository()
+_user_profile_service = UserProfileService(repo=_user_profile_repository)
 
 # Family Tree 服務
 _family_tree_service = FamilyTreeService()
-
-# LIFF Auth 服務
-_line_id_token_service = LineIdTokenService()
-_app_jwt_service = AppJwtService(
-    secret=settings.AUTH_JWT_SECRET,
-    algorithm=settings.AUTH_JWT_ALGORITHM,
-    expires_minutes=settings.AUTH_JWT_EXPIRES_MINUTES,
-)
-_liff_auth_application_service = LiffAuthApplicationService(
-    line_id_token_service=_line_id_token_service,
-    jwt_service=_app_jwt_service,
-)
 
 
 def get_mongodb_url() -> str:
@@ -125,38 +107,9 @@ def get_vector_search_reader() -> MongoVectorSearchReader:
     return _vector_search_reader
 
 
-def get_user_profile_service() -> ProfileService:
-    return _profile_service
+def get_user_profile_service() -> UserProfileService:
+    return _user_profile_service
 
 
 def get_family_tree_service() -> FamilyTreeService:
     return _family_tree_service
-
-
-def get_liff_auth_application_service() -> LiffAuthApplicationService:
-    return _liff_auth_application_service
-
-
-@dataclass
-class CurrentUser:
-    line_user_id: str
-
-
-def get_current_user(authorization: str | None = Header(default=None)) -> CurrentUser:
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Missing Authorization header")
-
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token.strip():
-        raise HTTPException(status_code=401, detail="Invalid Authorization header format")
-
-    try:
-        line_user_id = _app_jwt_service.decode_user_id(token.strip())
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Token expired")
-    except jwt.InvalidTokenError:
-        raise HTTPException(status_code=401, detail="Invalid token")
-    except ValueError:
-        raise HTTPException(status_code=401, detail="Invalid token payload")
-
-    return CurrentUser(line_user_id=line_user_id)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -64,8 +64,8 @@ _line_event_handler = LineEventHandler(
 )
 
 # 使用者資料相關的依賴注入
-_profile_repository = UserProfileRepository()
-_profile_service = UserProfileService(repo=_profile_repository)
+_user_profile_repository = UserProfileRepository()
+_user_profile_service = UserProfileService(repo=_user_profile_repository)
 
 # Family Tree 服務
 _family_tree_service = FamilyTreeService()
@@ -127,7 +127,7 @@ def get_vector_search_reader() -> MongoVectorSearchReader:
 
 
 def get_user_profile_service() -> UserProfileService:
-    return _profile_service
+    return _user_profile_service
 
 
 def get_family_tree_service() -> FamilyTreeService:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class UserProfileData(BaseModel):
+    """
+    使用者健康資料的model
+
+    設計目的：
+    1. 集中定義 user profile 的欄位與驗證規則。
+    2. 同一份欄位可被「API 請求模型」與「資料庫文件模型」重複使用。
+    """
+
+    # field 內的 ... 代表必填欄位。
+    name: str = Field(..., min_length=1, description="User display name")
+    gender: str = Field(..., min_length=1, description="User gender")
+    height: float = Field(..., gt=0, description="Height in cm")
+    weight: float = Field(..., gt=0, description="Weight in kg")
+    age: int = Field(..., ge=0, le=130, description="Age in years")
+
+    # 慢性病史固定為字串格式。
+    chronic_history: str = Field(..., description="Chronic disease history")
+
+    # 下列兩個欄位目前以文字輸入
+    major_illness_history: str = Field(..., description="Major illness history")
+    surgery_history: str = Field(..., description="Surgery history")
+
+    # 健康諮詢記錄使用 JSON 物件，預設空 dict
+    health_consultations: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Health consultation records in JSON format",
+    )
+
+
+# 這裡userprofile繼承userprofiledata，並且加上line_id、created_at、updated_at等欄位
+class UserProfile(UserProfileData):
+    """
+    資料庫中的 user profile 文件模型。
+
+    相較於 UserProfileData，這裡額外補上：
+    - line_id: 主識別（LINE UID）
+    - created_at / updated_at: DB 寫入時的時間戳
+    """
+
+    line_id: str = Field(..., min_length=1, description="LINE user ID")
+    created_at: Optional[datetime] = Field(
+        default=None,
+        description="UTC timestamp when profile was created",
+    )
+    updated_at: Optional[datetime] = Field(
+        default=None,
+        description="UTC timestamp when profile was last updated",
+    )
+
+    @classmethod
+    def from_upsert(cls, line_id: str, payload: Dict[str, Any]) -> "UserProfile":
+        """
+        由 upsert 參數建立 UserProfile，並在建立時觸發完整驗證。
+
+        使用情境：
+        - service 層拿到 API payload 後，先轉成模型再交給 repository
+        - 可避免未驗證的 dict 直接進入 DB 操作
+        """
+
+        return cls(line_id=line_id, **payload)
+
+    def to_payload(self) -> Dict[str, Any]:
+        """
+        將模型序列化成 repository 可直接寫入的 payload。
+        """
+        # 這裡排除 created_at 和 updated_at，因為這兩個欄位由 repository 在寫入時自動添加。
+        return self.model_dump(exclude={"created_at", "updated_at"})
+
+
+# __all__表示當其他文件使用 import * 時，僅會匯入 UserProfileData 和
+# UserProfile 這兩個類別。
+__all__ = ["UserProfileData", "UserProfile"]

--- a/app/repositories/user_profile_repository.py
+++ b/app/repositories/user_profile_repository.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class UserProfileRepository:
     @staticmethod
-    async def upsert_profile(line_id: str, payload: Dict[str, Any]) -> bool:
+    async def upsert_user_profile(line_id: str, payload: Dict[str, Any]) -> bool:
         col = MongoDBManager.get_users_collection()
         now = datetime.now(tz=timezone.utc)
         result = await col.update_one(
@@ -27,6 +27,6 @@ class UserProfileRepository:
         return result.matched_count > 0 or result.upserted_id is not None
 
     @staticmethod
-    async def get_profile(line_id: str) -> Optional[Dict[str, Any]]:
-        col = MongoDBManager.get_profile_collection()
+    async def get_user_profile(line_id: str) -> Optional[Dict[str, Any]]:
+        col = MongoDBManager.get_users_collection()
         return await col.find_one({"line_id": line_id})

--- a/app/repositories/user_profile_repository.py
+++ b/app/repositories/user_profile_repository.py
@@ -29,4 +29,8 @@ class UserProfileRepository:
     @staticmethod
     async def get_user_profile(line_id: str) -> Optional[Dict[str, Any]]:
         col = MongoDBManager.get_users_collection()
-        return await col.find_one({"line_id": line_id})
+        profile = await col.find_one({"line_id": line_id})
+        if profile:
+            # 移除 MongoDB 的 _id 欄位以便 JSON 序列化
+            profile.pop("_id", None)
+        return profile

--- a/app/routers/users/upsert_users.py
+++ b/app/routers/users/upsert_users.py
@@ -7,6 +7,30 @@ from app.dependencies import get_user_profile_service, get_current_user, Current
 router = APIRouter(tags=["Profile"])
 
 
+@router.get("/{user_id}")
+async def get_user_profile(
+    user_id: str,
+    current_user: CurrentUser = Depends(get_current_user),
+    service: UserProfileService = Depends(get_user_profile_service),
+):
+    """
+    取得使用者個人健康資料
+    需要有效的 JWT 認證令牌
+    """
+    # 確保使用者只能查看自己的資料
+    if current_user.line_user_id != user_id:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=403, detail="無權查看其他使用者的資料")
+
+    profile = await service.get_user_profile(user_id)
+    if not profile:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail="找不到使用者資料")
+    return profile
+
+
 @router.put("/{user_id}")
 async def upsert_user_profile(
     user_id: str,
@@ -16,7 +40,7 @@ async def upsert_user_profile(
 ):
     """
     更新使用者個人健康資料
-    需要有效的 JWT 認證令牌
+    需要帶上有效的 JWT 認證令牌
     """
     # 確保使用者只能修改自己的資料
     if current_user.line_user_id != user_id:

--- a/app/routers/users/upsert_users.py
+++ b/app/routers/users/upsert_users.py
@@ -1,16 +1,28 @@
 from fastapi import APIRouter, Depends
-from app.schemas import ProfileUpsertRequest, ProfileUpsertResponse
-from app.application.users.profile_service import ProfileService
-from app.dependencies import get_user_profile_service
 
-router = APIRouter(tags=["Profile"])  #
+from app.models.user import UserProfileData
+from app.services.users.user_profile_service import UserProfileService
+from app.dependencies import get_user_profile_service, get_current_user, CurrentUser
+
+router = APIRouter(tags=["Profile"])
 
 
-@router.put("/{user_id}", response_model=ProfileUpsertResponse)
-async def upsert_profile(
+@router.put("/{user_id}")
+async def upsert_user_profile(
     user_id: str,
-    body: ProfileUpsertRequest,
-    service: ProfileService = Depends(get_user_profile_service),
+    body: UserProfileData,
+    current_user: CurrentUser = Depends(get_current_user),
+    service: UserProfileService = Depends(get_user_profile_service),
 ):
-    updated = await service.upsert_profile(user_id, body.model_dump())
-    return ProfileUpsertResponse(user_id=user_id, updated=updated)
+    """
+    更新使用者個人健康資料
+    需要有效的 JWT 認證令牌
+    """
+    # 確保使用者只能修改自己的資料
+    if current_user.line_user_id != user_id:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=403, detail="無權修改其他使用者的資料")
+
+    updated = await service.upsert_user_profile(user_id, body.model_dump())
+    return {"user_id": user_id, "updated": updated}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -77,20 +77,3 @@ class MedicalFacility(BaseModel):
     distance_meters: Optional[float] = Field(
         None, description="距離用戶的直線距離（公尺），由 PostGIS 計算填入"
     )
-
-class ProfileUpsertRequest(BaseModel):
-    """使用者健康資料更新請求模型"""
-    name: str = Field(..., description="姓名")
-    gender: str = Field(..., description="性別")
-    height: float = Field(..., description="身高")
-    weight: float = Field(..., description="體重")
-    age: int = Field(..., description="年齡")
-    chronic_history: str = Field(..., description="慢性病史")
-    major_illness_history: str = Field(..., description="重大傷病紀錄")
-    surgery_history: str = Field(..., description="開刀紀錄")
-    health_consultations: Dict[str, Any] = Field(..., description="健康諮詢紀錄(JSON)")
-
-class ProfileUpsertResponse(BaseModel):
-    """使用者健康資料更新回應模型"""
-    user_id: str
-    updated: bool

--- a/app/services/users/user_profile_service.py
+++ b/app/services/users/user_profile_service.py
@@ -1,0 +1,20 @@
+from app.models.user import UserProfile
+from app.repositories.user_profile_repository import UserProfileRepository
+
+
+class UserProfileService:
+    """使用者健康資料服務層。"""
+
+    def __init__(self, repo: UserProfileRepository) -> None:
+        self._repo = repo
+
+    async def upsert_user_profile(self, line_id: str, payload: dict) -> bool:
+        """
+        驗證 payload 後寫入資料庫。
+
+        chronic_history 目前固定使用字串格式。
+        """
+
+        profile = UserProfile.from_upsert(line_id=line_id, payload=payload)
+        normalized_payload = profile.to_payload()
+        return await self._repo.upsert_user_profile(line_id, normalized_payload)

--- a/app/services/users/user_profile_service.py
+++ b/app/services/users/user_profile_service.py
@@ -18,3 +18,9 @@ class UserProfileService:
         profile = UserProfile.from_upsert(line_id=line_id, payload=payload)
         normalized_payload = profile.to_payload()
         return await self._repo.upsert_user_profile(line_id, normalized_payload)
+
+    async def get_user_profile(self, line_id: str):
+        """
+        從資料庫取得使用者個人健康資料。
+        """
+        return await self._repo.get_user_profile(line_id)

--- a/frontend/liff-app/src/api/profileApi.ts
+++ b/frontend/liff-app/src/api/profileApi.ts
@@ -1,0 +1,39 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:8000'
+
+export type UpsertPersonalHealthPayload = {
+    name: string
+    gender: string
+    height: number
+    weight: number
+    age: number
+    chronic_history: string
+    major_illness_history: string
+    surgery_history: string
+    health_consultations: Record<string, unknown>
+}
+
+export async function upsertPersonalHealthProfile(
+    userId: string,
+    payload: UpsertPersonalHealthPayload,
+) {
+    const token = (localStorage.getItem('CARE_AUTH_TOKEN') || '').trim()
+    if (!token) {
+        throw new Error('缺少登入憑證，請先重新登入')
+    }
+
+    const res = await fetch(`${BASE_URL}/profiles/${userId}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+    })
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`個人資料儲存失敗：${res.status}${text ? ` - ${text}` : ''}`)
+    }
+
+    return res.json()
+}

--- a/frontend/liff-app/src/api/profileApi.ts
+++ b/frontend/liff-app/src/api/profileApi.ts
@@ -37,3 +37,25 @@ export async function upsertPersonalHealthProfile(
 
     return res.json()
 }
+
+export async function getPersonalHealthProfile(userId: string) {
+    const token = (localStorage.getItem('CARE_AUTH_TOKEN') || '').trim()
+    if (!token) {
+        throw new Error('缺少登入憑證，請先重新登入')
+    }
+
+    const res = await fetch(`${BASE_URL}/profiles/${userId}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+    })
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`取得個人資料失敗：${res.status}${text ? ` - ${text}` : ''}`)
+    }
+
+    return res.json()
+}

--- a/frontend/liff-app/src/components/BottomNav/index.tsx
+++ b/frontend/liff-app/src/components/BottomNav/index.tsx
@@ -20,22 +20,22 @@ function BottomNav() {
         <span className="label">{t('nav.home')}</span>
       </button>
       <button
-        className={`nav-item ${isActive('/PersonalHealth')}`}
-        onClick={() => navigate('/PersonalHealth')}
+        className={`nav-item ${isActive('/personalhealth')}`}
+        onClick={() => navigate('/personalhealth')}
       >
         <span className="icon">🏥</span>
         <span className="label">{t('nav.health')}</span>
       </button>
       <button
-        className={`nav-item ${isActive('/Family')}`}
-        onClick={() => navigate('/Family')}
+        className={`nav-item ${isActive('/family')}`}
+        onClick={() => navigate('/family')}
       >
         <span className="icon">👥</span>
         <span className="label">{t('nav.family')}</span>
       </button>
       <button
-        className={`nav-item ${isActive('/Settings')}`}
-        onClick={() => navigate('/Settings')}
+        className={`nav-item ${isActive('/settings')}`}
+        onClick={() => navigate('/settings')}
       >
         <span className="icon">⚙️</span>
         <span className="label">{t('nav.settings')}</span>

--- a/frontend/liff-app/src/components/Sidebar/index.tsx
+++ b/frontend/liff-app/src/components/Sidebar/index.tsx
@@ -13,13 +13,13 @@ function Sidebar() {
         <button className={`side-item ${isActive('/')}`} onClick={() => navigate('/')}>
           <span className="icon">🏠</span>首頁
         </button>
-        <button className={`side-item ${isActive('/personalhealth')}`} onClick={() => navigate('/PersonalHealth')}>
+        <button className={`side-item ${isActive('/personalhealth')}`} onClick={() => navigate('/personalhealth')}>
           <span className="icon">🏥</span>個人健康
         </button>
         <button className={`side-item ${isActive('/family')}`} onClick={() => navigate('/family')}>
           <span className="icon">👥</span>家庭介面
         </button>
-        <button className={`side-item ${isActive('/settings')}`} onClick={() => navigate('/Settings')}>
+        <button className={`side-item ${isActive('/settings')}`} onClick={() => navigate('/settings')}>
           <span className="icon">⚙️</span>系統設定
         </button>
       </nav>

--- a/frontend/liff-app/src/main.tsx
+++ b/frontend/liff-app/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/frontend/liff-app/src/pages/Loginpage/index.tsx
+++ b/frontend/liff-app/src/pages/Loginpage/index.tsx
@@ -10,7 +10,6 @@ function LoginPage() {
 	const navigate = useNavigate()
 	const [statusText, setStatusText] = useState('正在初始化 LINE 登入...')
 	const [errorText, setErrorText] = useState('')
-
 	useEffect(() => {
 		let cancelled = false
 
@@ -40,7 +39,8 @@ function LoginPage() {
 				const authResult = await loginWithLiffIdToken(idToken)
 				localStorage.setItem('CARE_AUTH_TOKEN', authResult.access_token)
 				localStorage.setItem('CARE_LINE_USER_ID', authResult.line_user_id)
-
+				console.log("authResult.access_token:", authResult.access_token)
+				console.log("authResult.line_user_id:", authResult.line_user_id)
 				setStatusText('驗證成功，正在返回首頁...')
 				navigate('/', { replace: true })
 			} catch (error) {

--- a/frontend/liff-app/src/pages/Loginpage/index.tsx
+++ b/frontend/liff-app/src/pages/Loginpage/index.tsx
@@ -10,6 +10,7 @@ function LoginPage() {
 	const navigate = useNavigate()
 	const [statusText, setStatusText] = useState('正在初始化 LINE 登入...')
 	const [errorText, setErrorText] = useState('')
+
 	useEffect(() => {
 		let cancelled = false
 
@@ -39,8 +40,7 @@ function LoginPage() {
 				const authResult = await loginWithLiffIdToken(idToken)
 				localStorage.setItem('CARE_AUTH_TOKEN', authResult.access_token)
 				localStorage.setItem('CARE_LINE_USER_ID', authResult.line_user_id)
-				console.log("authResult.access_token:", authResult.access_token)
-				console.log("authResult.line_user_id:", authResult.line_user_id)
+
 				setStatusText('驗證成功，正在返回首頁...')
 				navigate('/', { replace: true })
 			} catch (error) {

--- a/frontend/liff-app/src/pages/PersonalHealth/index.css
+++ b/frontend/liff-app/src/pages/PersonalHealth/index.css
@@ -23,6 +23,66 @@
     flex-direction: column;
 }
 
+/* 使用者資訊卡 */
+.profileBanner {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 18px 20px;
+    margin-bottom: 20px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(13, 148, 136, 0.12), rgba(255, 255, 255, 0.96));
+    border: 1px solid rgba(13, 148, 136, 0.12);
+    box-shadow: 0 10px 24px rgba(13, 148, 136, 0.08);
+}
+
+.profileAvatarWrap {
+    flex: 0 0 auto;
+}
+
+.profileAvatar {
+    width: 76px;
+    height: 76px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid #ffffff;
+    box-shadow: 0 8px 18px rgba(13, 148, 136, 0.15);
+    background: #e2e8f0;
+}
+
+.profileAvatarFallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.profileBannerText {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+    padding-top: 4px;
+}
+
+.profileBannerLabel {
+    font-family: 'Microsoft JhengHei', 'Noto Sans TC', sans-serif;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #64748b;
+}
+
+.profileBannerTitle {
+    margin-bottom: 0;
+
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text-color);
+    word-break: break-word;
+}
+
 /* 表單容器 */
 .formContainer {
     width: 100%;
@@ -373,6 +433,29 @@ consultRecord {
 
 /* 手機版 */
 @media (max-width: 600px) {
+    .profileBanner {
+        padding: 16px;
+        gap: 14px;
+    }
+
+    .profileBannerText {
+        padding-top: 2px;
+        gap: 8px;
+    }
+
+    .profileBannerLabel {
+        font-size: 1rem;
+    }
+
+    .profileAvatar {
+        width: 64px;
+        height: 64px;
+    }
+
+    .profileBannerTitle {
+        font-size: 1.2rem;
+    }
+
     .formGroup {
         flex-direction: column;
         align-items: flex-start;

--- a/frontend/liff-app/src/pages/PersonalHealth/index.tsx
+++ b/frontend/liff-app/src/pages/PersonalHealth/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { upsertPersonalHealthProfile } from '../../api/profileApi';
+import { upsertPersonalHealthProfile, getPersonalHealthProfile } from '../../api/profileApi';
 
 import './index.css';
 /*http://localhost:5173/personalHealth*/
@@ -109,6 +109,44 @@ const PersonalHealthPage: React.FC = () => {
         if (avatarUrl) {
             setUserAvatar(avatarUrl);
         }
+
+        // 讀取使用者資料，預填表單
+        const loadUserData = async () => {
+            const userId = (localStorage.getItem('CARE_LINE_USER_ID') || '').trim();
+            if (!userId) {
+                console.log('未找到使用者ID，跳過加載資料');
+                return;
+            }
+
+            try {
+                //呼叫api取得user資料
+                const data = await getPersonalHealthProfile(userId);
+                console.log('已加載使用者資料:', data);
+                if (data) {
+                    setForm((prev) => ({
+                        ...prev,
+                        name: data.name || prev.name,  // 資料庫優先，沒有才用LINE 名稱
+                        gender: data.gender || '',
+                        height: data.height?.toString() || '',
+                        weight: data.weight?.toString() || '',
+                        age: data.age?.toString() || '',
+                        chronicDisease: data.chronic_history ? data.chronic_history.split('、').filter(Boolean) : [],
+                        chronicDiseaseOther: '',
+                        majorIllness: data.major_illness_history || '',
+                        surgeryHistory: data.surgery_history || '',
+                    }));
+                    // 若資料庫有 name，也更新顯示用的 userName
+                    if (data.name) {
+                        setUserName(data.name);
+                    }
+                }
+            } catch (error) {
+                console.warn('載入使用者資料失敗:', error);
+                // 不阻斷頁面使用
+            }
+        };
+
+        loadUserData();
     }, []);
 
 
@@ -244,6 +282,11 @@ const PersonalHealthPage: React.FC = () => {
         !!form.majorIllness ||
         !!otherInput;
 
+    const isLoggedIn = Boolean(
+        (localStorage.getItem('CARE_AUTH_TOKEN') || '').trim() &&
+        (localStorage.getItem('CARE_LINE_USER_ID') || '').trim()
+    );
+
     return (
         <div className="pageContainer">
             <section className="profileBanner">
@@ -261,7 +304,7 @@ const PersonalHealthPage: React.FC = () => {
                     )}
                 </div>
                 <div className="profileBannerText">
-                    <div className="profileBannerLabel">已登入</div>
+                    <div className="profileBannerLabel">{isLoggedIn ? '已登入' : '您尚未登入!'}</div>
                     <div className="formTitle profileBannerTitle">{userName ? `${userName} 的健康資料` : '個人健康資料'}</div>
                 </div>
             </section>

--- a/frontend/liff-app/src/pages/PersonalHealth/index.tsx
+++ b/frontend/liff-app/src/pages/PersonalHealth/index.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import liff from '@line/liff';
+import { upsertPersonalHealthProfile } from '../../api/profileApi';
+
 import './index.css';
 /*http://localhost:5173/personalHealth*/
 interface HealthData {
@@ -44,6 +47,7 @@ const PersonalHealthPage: React.FC = () => {
     const [form, setForm] = useState<HealthData>(defaultData);
     const [otherInput, setOtherInput] = useState('');
     const [otherSaved, setOtherSaved] = useState(false);
+    const [storageEntries, setStorageEntries] = useState<Array<{ key: string; value: string }>>([]);
     // 儲存成功提示狀態
     const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
     // 儲存提示訊息
@@ -52,7 +56,31 @@ const PersonalHealthPage: React.FC = () => {
     const [isChronicOpen, setIsChronicOpen] = useState(false);
     // 修改：性別下拉開關
     const [isGenderOpen, setIsGenderOpen] = useState(false);
+    // 顯示使用者名稱
+    const [userName] = useState<string>('');
     const navigate = useNavigate();
+
+    const refreshStorageEntries = () => {
+        const entries: Array<{ key: string; value: string }> = [];
+        for (let index = 0; index < localStorage.length; index += 1) {
+            const key = localStorage.key(index);
+            if (!key) {
+                continue;
+            }
+            entries.push({ key, value: localStorage.getItem(key) ?? '' });
+        }
+        entries.sort((left, right) => left.key.localeCompare(right.key));
+        setStorageEntries(entries);
+        console.table(entries);
+    };
+
+    useEffect(() => {
+        const displayName = (localStorage.getItem('CARE_LINE_DISPLAY_NAME') || '').trim();
+        if (displayName) {
+            setForm((prev) => ({ ...prev, name: prev.name || displayName }));
+        }
+    }, []);
+
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
@@ -130,9 +158,16 @@ const PersonalHealthPage: React.FC = () => {
         };
 
         console.log("最終提交資料：", finalData);
-        // TODO: 你要用真實 LINE user_id，先暫時手動填入或從 LIFF 取得
-        const userId = "123456789";
-
+        // 不再寫死Id，而是從 LIFF 取得 userId 作為 API 識別用
+        const userId = (localStorage.getItem('CARE_LINE_USER_ID') || '').trim();
+        if (!userId) {
+            setSaveMessage('找不到 LINE 使用者資訊，請先重新登入');
+            setSaveStatus('error');
+            return;
+        }
+        const userName = (await liff.getProfile()).displayName;
+        console.log("LIFF User ID:", userId);
+        console.log("LIFF User Name:", userName);
         const payload = {
             name: finalData.name,
             gender: finalData.gender,
@@ -142,37 +177,19 @@ const PersonalHealthPage: React.FC = () => {
             // 修改：慢性病史改為可複選，後端目前是字串欄位
             chronic_history: finalData.chronicDisease.join('、'),
             major_illness_history: finalData.majorIllness,
-            surgery_history: finalData.surgeryHistory,
+            surgery_history: finalData.surgeryHistory || '無',
             health_consultations: {} // 先放空 JSON
         };
 
-        const baseUrl = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:8000";
 
         try {
-            const res = await fetch(`${baseUrl}/profiles/${userId}`, {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(payload)
-            });
-
-            if (!res.ok) {
-                const text = await res.text();
-                console.error("儲存失敗:", text);
-                // 儲存失敗提示狀態
-                setSaveMessage('儲存失敗，請稍後再試');
-                setSaveStatus('error');
-                return;
-            }
-
-            const data = await res.json();
-            console.log("儲存成功:", data);
-            // 儲存成功提示狀態
+            const data = await upsertPersonalHealthProfile(userId, payload);
+            console.log('儲存成功:', data);
             setSaveMessage('已成功儲存個人健康資料');
             setSaveStatus('success');
         } catch (error) {
             console.error('儲存失敗（網路或請求中斷）:', error);
-            // 儲存失敗提示狀態
-            setSaveMessage('網路異常，請稍後再試');
+            setSaveMessage(error instanceof Error ? error.message : '網路異常，請稍後再試');
             setSaveStatus('error');
         }
     };
@@ -199,6 +216,37 @@ const PersonalHealthPage: React.FC = () => {
 
     return (
         <div className="pageContainer">
+            <section style={{ marginBottom: '16px', padding: '12px', border: '1px solid #dbeafe', borderRadius: '12px', background: '#f8fbff' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
+                    <strong>localStorage 除錯視圖</strong>
+                    <button type="button" onClick={refreshStorageEntries} className="button" style={{ padding: '8px 12px' }}>
+                        重新讀取
+                    </button>
+                </div>
+                {storageEntries.length === 0 ? (
+                    <div style={{ color: '#64748b' }}>目前沒有任何 localStorage 資料</div>
+                ) : (
+                    <div style={{ overflowX: 'auto' }}>
+                        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+                            <thead>
+                                <tr>
+                                    <th style={{ textAlign: 'left', padding: '8px', borderBottom: '1px solid #cbd5e1' }}>key</th>
+                                    <th style={{ textAlign: 'left', padding: '8px', borderBottom: '1px solid #cbd5e1' }}>value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {storageEntries.map((entry) => (
+                                    <tr key={entry.key}>
+                                        <td style={{ padding: '8px', borderBottom: '1px solid #e2e8f0', whiteSpace: 'nowrap' }}>{entry.key}</td>
+                                        <td style={{ padding: '8px', borderBottom: '1px solid #e2e8f0', wordBreak: 'break-all' }}>{entry.value}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </section>
+
             {/* 儲存成功/失敗提示 */}
             {saveStatus === 'success' && (
                 <div className="saveToast saveToastSuccess">{saveMessage || '已成功儲存個人健康資料'}</div>
@@ -207,7 +255,7 @@ const PersonalHealthPage: React.FC = () => {
                 <div className="saveToast saveToastError">{saveMessage || '儲存失敗，請稍後再試'}</div>
             )}
             <form id="personalHealthForm" className="formContainer" onSubmit={handleSubmit}>
-                <div className="formTitle">個人健康資料</div>
+                <div className="formTitle">{userName ? `${userName} 的健康資料` : '個人健康資料'}</div>
                 <div className="formGroup">
                     <label className="label" htmlFor="name">姓名</label>
                     <input
@@ -217,6 +265,7 @@ const PersonalHealthPage: React.FC = () => {
                         name="name"
                         value={form.name}
                         onChange={handleChange}
+                        /*若有登入就顯示user名字*/
                         placeholder="請輸入姓名"
                         required
                     />

--- a/frontend/liff-app/src/pages/PersonalHealth/index.tsx
+++ b/frontend/liff-app/src/pages/PersonalHealth/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import liff from '@line/liff';
 import { upsertPersonalHealthProfile } from '../../api/profileApi';
 
 import './index.css';
@@ -16,6 +15,11 @@ interface HealthData {
     chronicDiseaseOther: string;
     majorIllness: string;
     surgeryHistory?: string;
+}
+
+interface DecodedIdToken {
+    name?: string;
+    picture?: string;
 }
 
 const defaultData: HealthData = {
@@ -47,7 +51,6 @@ const PersonalHealthPage: React.FC = () => {
     const [form, setForm] = useState<HealthData>(defaultData);
     const [otherInput, setOtherInput] = useState('');
     const [otherSaved, setOtherSaved] = useState(false);
-    const [storageEntries, setStorageEntries] = useState<Array<{ key: string; value: string }>>([]);
     // 儲存成功提示狀態
     const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
     // 儲存提示訊息
@@ -56,28 +59,55 @@ const PersonalHealthPage: React.FC = () => {
     const [isChronicOpen, setIsChronicOpen] = useState(false);
     // 修改：性別下拉開關
     const [isGenderOpen, setIsGenderOpen] = useState(false);
-    // 顯示使用者名稱
-    const [userName] = useState<string>('');
+    // 顯示使用者名稱與頭像
+    const [userName, setUserName] = useState<string>('');
+    const [userAvatar, setUserAvatar] = useState<string>('');
     const navigate = useNavigate();
 
-    const refreshStorageEntries = () => {
-        const entries: Array<{ key: string; value: string }> = [];
-        for (let index = 0; index < localStorage.length; index += 1) {
-            const key = localStorage.key(index);
-            if (!key) {
-                continue;
+    const readDecodedIdToken = (): DecodedIdToken | null => {
+        const liffId = (import.meta.env.VITE_LIFF_ID ?? '').trim();
+        if (liffId) {
+            const storedKey = `LIFF_STORE:${liffId}:decodedIDToken`;
+            const storedValue = localStorage.getItem(storedKey);
+            if (storedValue) {
+                try {
+                    return JSON.parse(storedValue) as DecodedIdToken;
+                } catch (error) {
+                    console.warn('解析 decodedIDToken 失敗:', error);
+                }
             }
-            entries.push({ key, value: localStorage.getItem(key) ?? '' });
         }
-        entries.sort((left, right) => left.key.localeCompare(right.key));
-        setStorageEntries(entries);
-        console.table(entries);
+
+        const fallbackKey = Object.keys(localStorage).find((key) => key.endsWith(':decodedIDToken'));
+        if (!fallbackKey) {
+            return null;
+        }
+
+        const fallbackValue = localStorage.getItem(fallbackKey);
+        if (!fallbackValue) {
+            return null;
+        }
+
+        try {
+            return JSON.parse(fallbackValue) as DecodedIdToken;
+        } catch (error) {
+            console.warn('解析 fallback decodedIDToken 失敗:', error);
+            return null;
+        }
     };
 
     useEffect(() => {
-        const displayName = (localStorage.getItem('CARE_LINE_DISPLAY_NAME') || '').trim();
+        const decodedIdToken = readDecodedIdToken();
+        const displayName = (decodedIdToken?.name || localStorage.getItem('CARE_LINE_DISPLAY_NAME') || '').trim();
+        const avatarUrl = (decodedIdToken?.picture || '').trim();
+
         if (displayName) {
+            setUserName(displayName);
             setForm((prev) => ({ ...prev, name: prev.name || displayName }));
+        }
+
+        if (avatarUrl) {
+            setUserAvatar(avatarUrl);
         }
     }, []);
 
@@ -165,9 +195,9 @@ const PersonalHealthPage: React.FC = () => {
             setSaveStatus('error');
             return;
         }
-        const userName = (await liff.getProfile()).displayName;
+        const profileName = userName || (readDecodedIdToken()?.name || '').trim();
         console.log("LIFF User ID:", userId);
-        console.log("LIFF User Name:", userName);
+        console.log("LIFF User Name:", profileName);
         const payload = {
             name: finalData.name,
             gender: finalData.gender,
@@ -216,35 +246,24 @@ const PersonalHealthPage: React.FC = () => {
 
     return (
         <div className="pageContainer">
-            <section style={{ marginBottom: '16px', padding: '12px', border: '1px solid #dbeafe', borderRadius: '12px', background: '#f8fbff' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-                    <strong>localStorage 除錯視圖</strong>
-                    <button type="button" onClick={refreshStorageEntries} className="button" style={{ padding: '8px 12px' }}>
-                        重新讀取
-                    </button>
+            <section className="profileBanner">
+                <div className="profileAvatarWrap">
+                    {userAvatar ? (
+                        <img
+                            className="profileAvatar"
+                            src={userAvatar}
+                            alt={userName ? `${userName} 的頭像` : '使用者頭像'}
+                        />
+                    ) : (
+                        <div className="profileAvatar profileAvatarFallback" aria-hidden="true">
+                            {userName ? userName.charAt(0) : 'U'}
+                        </div>
+                    )}
                 </div>
-                {storageEntries.length === 0 ? (
-                    <div style={{ color: '#64748b' }}>目前沒有任何 localStorage 資料</div>
-                ) : (
-                    <div style={{ overflowX: 'auto' }}>
-                        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
-                            <thead>
-                                <tr>
-                                    <th style={{ textAlign: 'left', padding: '8px', borderBottom: '1px solid #cbd5e1' }}>key</th>
-                                    <th style={{ textAlign: 'left', padding: '8px', borderBottom: '1px solid #cbd5e1' }}>value</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {storageEntries.map((entry) => (
-                                    <tr key={entry.key}>
-                                        <td style={{ padding: '8px', borderBottom: '1px solid #e2e8f0', whiteSpace: 'nowrap' }}>{entry.key}</td>
-                                        <td style={{ padding: '8px', borderBottom: '1px solid #e2e8f0', wordBreak: 'break-all' }}>{entry.value}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                )}
+                <div className="profileBannerText">
+                    <div className="profileBannerLabel">已登入</div>
+                    <div className="formTitle profileBannerTitle">{userName ? `${userName} 的健康資料` : '個人健康資料'}</div>
+                </div>
             </section>
 
             {/* 儲存成功/失敗提示 */}
@@ -255,7 +274,6 @@ const PersonalHealthPage: React.FC = () => {
                 <div className="saveToast saveToastError">{saveMessage || '儲存失敗，請稍後再試'}</div>
             )}
             <form id="personalHealthForm" className="formContainer" onSubmit={handleSubmit}>
-                <div className="formTitle">{userName ? `${userName} 的健康資料` : '個人健康資料'}</div>
                 <div className="formGroup">
                     <label className="label" htmlFor="name">姓名</label>
                     <input

--- a/tests/unit/repositories/test_user_profile_repository.py
+++ b/tests/unit/repositories/test_user_profile_repository.py
@@ -1,0 +1,110 @@
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from app.repositories.user_profile_repository import UserProfileRepository
+
+
+# fixture用來在測試函數中提供一些預先設定好的物件或狀態，讓測試更簡潔和可重複使用
+# setattr:當 user_profile_repository.py 裡呼叫 MongoDBManager.get_users_collection() 時，
+# 不要跑真實的，改回傳我的 fake collection。
+@pytest.fixture()
+def override_users_collection(monkeypatch):
+    def _override(collection):
+        monkeypatch.setattr(
+            "app.repositories.user_profile_repository.MongoDBManager.get_users_collection",
+            lambda: collection,
+        )
+        return collection
+
+    return _override
+
+
+# 模擬 update_one 回傳 matched_count > 0（代表更新到既有資料）
+@pytest.mark.asyncio
+async def test_upsert_user_profile_returns_true_when_document_matched(
+    override_users_collection,
+):
+    collection = MagicMock()
+    collection.update_one = AsyncMock(
+        return_value=MagicMock(matched_count=1, upserted_id=None)
+    )
+    # 呼叫它，把 fake collection 傳進去，觸發 setattr 替換
+    override_users_collection(collection)
+
+    ok = await UserProfileRepository.upsert_user_profile("U123", {"name": "Amy"})
+
+    assert ok is True
+    collection.update_one.assert_awaited_once()
+
+
+# 模擬 matched_count = 0 但有 upserted_id（代表新插入成功）
+@pytest.mark.asyncio
+async def test_upsert_user_profile_returns_true_when_document_inserted(
+    override_users_collection,
+):
+    collection = MagicMock()
+    collection.update_one = AsyncMock(
+        return_value=MagicMock(matched_count=0, upserted_id="new-id")
+    )
+    override_users_collection(collection)
+
+    ok = await UserProfileRepository.upsert_user_profile("U123", {"name": "Amy"})
+
+    assert ok is True
+
+
+# matched_count 與 upserted_id 都無效時，應視為未成功寫入
+@pytest.mark.asyncio
+async def test_upsert_user_profile_returns_false_when_nothing_changed(
+    override_users_collection,
+):
+    collection = MagicMock()
+    collection.update_one = AsyncMock(
+        return_value=MagicMock(matched_count=0, upserted_id=None)
+    )
+    override_users_collection(collection)
+
+    ok = await UserProfileRepository.upsert_user_profile("U123", {"name": "Amy"})
+
+    assert ok is False
+
+
+# 驗證 update_one 的 filter / update / upsert 參數結構是否正確
+@pytest.mark.asyncio
+async def test_upsert_user_profile_builds_expected_update_query(
+    override_users_collection,
+):
+    collection = MagicMock()
+    collection.update_one = AsyncMock(
+        return_value=MagicMock(matched_count=1, upserted_id=None)
+    )
+    override_users_collection(collection)
+
+    payload = {"name": "Amy", "age": 30}
+    await UserProfileRepository.upsert_user_profile("U123", payload)
+
+    args, kwargs = collection.update_one.await_args
+    assert args[0] == {"line_id": "U123"}
+    assert kwargs["upsert"] is True
+
+    update_doc = args[1]
+    assert update_doc["$set"]["line_id"] == "U123"
+    assert update_doc["$set"]["name"] == "Amy"
+    assert update_doc["$set"]["age"] == 30
+    assert "updated_at" in update_doc["$set"]
+    assert "created_at" in update_doc["$setOnInsert"]
+
+
+# 測試 get_user_profile 能否正確呼叫 find_one 並回傳資料
+@pytest.mark.asyncio
+async def test_get_user_profile_uses_users_collection_and_returns_document(
+    override_users_collection,
+):
+    expected = {"line_id": "U123", "name": "Amy"}
+    collection = MagicMock()
+    collection.find_one = AsyncMock(return_value=expected)
+    override_users_collection(collection)
+
+    doc = await UserProfileRepository.get_user_profile("U123")
+
+    assert doc == expected
+    collection.find_one.assert_awaited_once_with({"line_id": "U123"})

--- a/tests/unit/routers/test_upsert_users.py
+++ b/tests/unit/routers/test_upsert_users.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi.testclient import TestClient
 
-from app.dependencies import get_user_profile_service
+from app.dependencies import CurrentUser, get_current_user, get_user_profile_service
 from app.main import app
 
 
@@ -37,6 +37,17 @@ def override_user_profile_service():
     app.dependency_overrides.clear()
 
 
+@pytest.fixture()
+def override_current_user():
+    def _override(user_id: str = "U123"):
+        app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+            line_user_id=user_id
+        )
+
+    yield _override
+    app.dependency_overrides.clear()
+
+
 # 下面是測試用的payload，包含所有必填欄位和一些範例資料。
 def _valid_payload() -> dict:
     return {
@@ -54,8 +65,9 @@ def _valid_payload() -> dict:
 
 # 測試成功的情況，應該回傳200和預期的response body
 def test_upsert_user_profile_success_returns_200_and_response_body(
-    client, override_user_profile_service
+    client, override_user_profile_service, override_current_user
 ):
+    override_current_user("U123")
     fake_service = override_user_profile_service(FakeUserProfileService(result=True))
 
     response = client.put("/profiles/U123", json=_valid_payload())
@@ -67,8 +79,9 @@ def test_upsert_user_profile_success_returns_200_and_response_body(
 
 # 測試payload缺少必填欄位的情況，應該回傳422 Unprocessable Entity
 def test_upsert_user_profile_invalid_body_returns_422(
-    client, override_user_profile_service
+    client, override_user_profile_service, override_current_user
 ):
+    override_current_user("U123")
     override_user_profile_service(FakeUserProfileService(result=True))
 
     invalid_payload = _valid_payload()
@@ -80,6 +93,9 @@ def test_upsert_user_profile_invalid_body_returns_422(
 
 # 測試service層發生錯誤的情況，應該回傳500 Internal Server Error
 def test_upsert_user_profile_service_error_returns_500(override_user_profile_service):
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        line_user_id="U123"
+    )
     fake_service = override_user_profile_service(
         FakeUserProfileService(error=RuntimeError("db down"))
     )

--- a/tests/unit/routers/test_upsert_users.py
+++ b/tests/unit/routers/test_upsert_users.py
@@ -1,0 +1,94 @@
+# tests/unit/routers/test_upsert_users.py
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.dependencies import get_user_profile_service
+from app.main import app
+
+
+class FakeUserProfileService:
+    def __init__(self, result: bool = True, error: Exception | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.upsert_user_profile = AsyncMock(side_effect=self._call)
+
+    async def _call(self, user_id: str, payload: dict) -> bool:
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+# 用dependency_overrides，把原本的get_user_profile_service改成
+# 用FakeUserProfileService來測試，避免呼叫service
+@pytest.fixture()
+def override_user_profile_service():
+    def _override(service: FakeUserProfileService):
+        app.dependency_overrides[get_user_profile_service] = lambda: service
+        return service
+
+    yield _override
+    app.dependency_overrides.clear()
+
+
+# 下面是測試用的payload，包含所有必填欄位和一些範例資料。
+def _valid_payload() -> dict:
+    return {
+        "name": "Amy",
+        "gender": "女性",
+        "height": 160.0,
+        "weight": 50.0,
+        "age": 30,
+        "chronic_history": "無",
+        "major_illness_history": "無",
+        "surgery_history": "無",
+        "health_consultations": {"last_visit": "2026-04-20"},
+    }
+
+
+# 測試成功的情況，應該回傳200和預期的response body
+def test_upsert_user_profile_success_returns_200_and_response_body(
+    client, override_user_profile_service
+):
+    fake_service = override_user_profile_service(FakeUserProfileService(result=True))
+
+    response = client.put("/profiles/U123", json=_valid_payload())
+    assert response.status_code == 200
+    assert response.json() == {"user_id": "U123", "updated": True}
+
+    fake_service.upsert_user_profile.assert_awaited_once()
+
+
+# 測試payload缺少必填欄位的情況，應該回傳422 Unprocessable Entity
+def test_upsert_user_profile_invalid_body_returns_422(
+    client, override_user_profile_service
+):
+    override_user_profile_service(FakeUserProfileService(result=True))
+
+    invalid_payload = _valid_payload()
+    invalid_payload.pop("name")
+
+    response = client.put("/profiles/U123", json=invalid_payload)
+    assert response.status_code == 422
+
+
+# 測試service層發生錯誤的情況，應該回傳500 Internal Server Error
+def test_upsert_user_profile_service_error_returns_500(override_user_profile_service):
+    fake_service = override_user_profile_service(
+        FakeUserProfileService(error=RuntimeError("db down"))
+    )
+
+    error_client = TestClient(app, raise_server_exceptions=False)
+    response = error_client.put("/profiles/U123", json=_valid_payload())
+    assert response.status_code == 500
+
+    fake_service.upsert_user_profile.assert_awaited_once()
+
+
+# 之後登入後端合併到main後要寫驗證使用者的測試

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -12,17 +12,20 @@ def test_getters_return_singleton_instances():
     assert dependencies.get_medical_service() is dependencies.medical_service
     assert dependencies.get_vector_search_config() is dependencies._vector_search_config
     assert dependencies.get_vector_search_reader() is dependencies._vector_search_reader
+    assert dependencies.get_user_profile_service() is dependencies._user_profile_service
 
 
 def test_dependency_wiring_is_correct():
     line_message_service = dependencies.get_line_message_service()
     handler = dependencies.get_line_event_handler()
+    profile_service = dependencies.get_user_profile_service()
 
     assert line_message_service.token_provider is dependencies.get_line_token_manager()
     assert line_message_service.medical_service is dependencies.get_medical_service()
     assert handler._line_message_service is line_message_service
     assert handler._medical_service is dependencies.get_medical_service()
     assert handler._response_orchestrator is dependencies._response_orchestrator
+    assert profile_service._repo is dependencies._user_profile_repository
 
 
 def test_get_mongodb_url_prefers_env_var(monkeypatch):


### PR DESCRIPTION
這次改動主要是在優化「使用者個人健康資料」的整體架構與體驗：

後端新增 Pydantic 資料模型與 Service layer，統一資料驗證與業務邏輯，並重構 repository 與 API 命名，使結構更清晰一致。同時新增 GET /profiles/{user_id}，並帶上 JWT token 驗證，確保只能存取自己的資料。

前端改用新 API 串接，重構 PersonalHealth 頁面資料載入與提交流程，加入 LINE LIFF 資訊預填、資料庫覆蓋 LINE fallback 邏輯，以及即時更新 UI。UI 方面新增使用者 banner、頭像顯示與響應式優化，並加入成功/失敗 toast 提示。

另外也調整 CORS 設定以支援 ngrok 開發環境。