### PR TITLE
後端驗證新增檢查並自動註冊步驟

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -88,6 +88,7 @@ _app_jwt_service = AppJwtService(
 _liff_auth_application_service = LiffAuthApplicationService(
     line_id_token_service=_line_id_token_service,
     jwt_service=_app_jwt_service,
+    user_profile_service=_user_profile_service,
 )
 
 

--- a/app/routers/liff/auth.py
+++ b/app/routers/liff/auth.py
@@ -32,5 +32,5 @@ async def liff_login(
     前端送 LIFF ID token，後端向 LINE verify endpoint 驗證後，
     簽發應用內 JWT 給前端後續 API 使用。
     """
-    result = service.login_with_id_token(req.id_token)
+    result = await service.login_with_id_token(req.id_token)
     return LiffLoginResponse(**result)

--- a/app/services/liff/auth_service.py
+++ b/app/services/liff/auth_service.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from app.core.config import settings
 from app.services.liff.jwt_service import AppJwtService
 from app.services.liff.line_id_token_service import LineIdTokenService
+from app.services.users.user_profile_service import UserProfileService
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +16,13 @@ class LiffAuthApplicationService:
         self,
         line_id_token_service: LineIdTokenService,
         jwt_service: AppJwtService,
+        user_profile_service: UserProfileService,
     ):
         self._line_id_token_service = line_id_token_service
         self._jwt_service = jwt_service
+        self._user_profile_service = user_profile_service
 
-    def login_with_id_token(self, id_token: str) -> dict:
+    async def login_with_id_token(self, id_token: str) -> dict:
         liff_client_id = settings.LIFF_CHANNEL_ID or settings.LINE_CHANNEL_ID
 
         if not liff_client_id:
@@ -49,6 +52,13 @@ class LiffAuthApplicationService:
         if not line_user_id:
             logger.error("LIFF ID token 驗證回應缺少 sub")
             raise HTTPException(status_code=401, detail="Invalid LIFF id_token payload")
+
+        profile = await self._user_profile_service.get_user_profile(line_user_id)
+        if not profile:
+            await self._user_profile_service.create_default_user_profile(
+                line_id=line_user_id,
+                display_name=verify_payload.get("name"),
+            )
 
         access_token, expires_in = self._jwt_service.issue_for_user(line_user_id)
         return {

--- a/app/services/users/user_profile_service.py
+++ b/app/services/users/user_profile_service.py
@@ -24,3 +24,24 @@ class UserProfileService:
         從資料庫取得使用者個人健康資料。
         """
         return await self._repo.get_user_profile(line_id)
+
+    async def create_default_user_profile(
+        self,
+        line_id: str,
+        display_name: str | None = None,
+    ) -> bool:
+        """
+        建立初始使用者資料，供首次登入且尚未填寫健康資料者使用。
+        """
+        default_payload = {
+            "name": (display_name or "LINE User").strip() or "LINE User",
+            "gender": "unknown",
+            "height": 1.0,
+            "weight": 1.0,
+            "age": 0,
+            "chronic_history": "",
+            "major_illness_history": "",
+            "surgery_history": "",
+            "health_consultations": {},
+        }
+        return await self.upsert_user_profile(line_id=line_id, payload=default_payload)

--- a/tests/unit/services/liff/test_auth_service.py
+++ b/tests/unit/services/liff/test_auth_service.py
@@ -1,0 +1,78 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.liff.auth_service import LiffAuthApplicationService
+
+
+@pytest.mark.asyncio
+async def test_login_with_id_token_creates_default_profile_when_user_not_found(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.liff.auth_service.settings.LIFF_CHANNEL_ID",
+        "liff-client-id",
+    )
+    monkeypatch.setattr(
+        "app.services.liff.auth_service.settings.LINE_CHANNEL_ID",
+        "line-client-id",
+    )
+
+    line_id_token_service = MagicMock()
+    line_id_token_service.verify.return_value = {"sub": "U123", "name": "Amy"}
+
+    jwt_service = MagicMock()
+    jwt_service.issue_for_user.return_value = ("app-jwt", 3600)
+
+    user_profile_service = MagicMock()
+    user_profile_service.get_user_profile = AsyncMock(return_value=None)
+    user_profile_service.create_default_user_profile = AsyncMock(return_value=True)
+
+    service = LiffAuthApplicationService(
+        line_id_token_service=line_id_token_service,
+        jwt_service=jwt_service,
+        user_profile_service=user_profile_service,
+    )
+
+    result = await service.login_with_id_token("id-token")
+
+    assert result["access_token"] == "app-jwt"
+    assert result["expires_in"] == 3600
+    assert result["line_user_id"] == "U123"
+    user_profile_service.get_user_profile.assert_awaited_once_with("U123")
+    user_profile_service.create_default_user_profile.assert_awaited_once_with(
+        line_id="U123",
+        display_name="Amy",
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_with_id_token_skips_create_when_user_exists(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.liff.auth_service.settings.LIFF_CHANNEL_ID",
+        "liff-client-id",
+    )
+    monkeypatch.setattr(
+        "app.services.liff.auth_service.settings.LINE_CHANNEL_ID",
+        "line-client-id",
+    )
+
+    line_id_token_service = MagicMock()
+    line_id_token_service.verify.return_value = {"sub": "U999", "name": "Bob"}
+
+    jwt_service = MagicMock()
+    jwt_service.issue_for_user.return_value = ("app-jwt", 1800)
+
+    user_profile_service = MagicMock()
+    user_profile_service.get_user_profile = AsyncMock(return_value={"line_id": "U999"})
+    user_profile_service.create_default_user_profile = AsyncMock(return_value=True)
+
+    service = LiffAuthApplicationService(
+        line_id_token_service=line_id_token_service,
+        jwt_service=jwt_service,
+        user_profile_service=user_profile_service,
+    )
+
+    result = await service.login_with_id_token("id-token")
+
+    assert result["line_user_id"] == "U999"
+    user_profile_service.get_user_profile.assert_awaited_once_with("U999")
+    user_profile_service.create_default_user_profile.assert_not_awaited()


### PR DESCRIPTION
後端使用者登入驗證時
加入自動註冊的功能，
透過在user_profile_service增加建立預設使用者資料方法實現