### PR TITLE
諮詢紀錄與摘要後端

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,9 @@ MONGODB_VECTOR_DIM=3072
 MEDIA_PARSE_WEBHOOK_URL=media_parse_webhook_url_here
 
 CORS_ALLOW_ORIGINS=liff_url
+
+# Redis 
+REDIS_URL=redis://default:your_password@your_host:your_port
+
+#自動摘要排程設定
+CONSULTATION_DAILY_SUMMARY_TIME=<hour>:<minute>  # 例如：23:00

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,5 +40,13 @@ class Settings:
     MONGODB_TEXT_FIELD: str = os.getenv("MONGODB_TEXT_FIELD", "text")
     MONGODB_VECTOR_DIM: int = int(os.getenv("MONGODB_VECTOR_DIM", "0"))
 
+    # Consultation / Redis 配置
+    REDIS_URL: str = os.getenv("REDIS_URL", "")
+
+    # Consultation daily summary scheduler
+    CONSULTATION_DAILY_SUMMARY_TIME: str = os.getenv(
+        "CONSULTATION_DAILY_SUMMARY_TIME", "02:00"
+    )
+
 
 settings = Settings()

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -119,6 +119,14 @@ def get_line_event_handler() -> LineEventHandler:
     return _line_event_handler
 
 
+def get_consultation_service() -> ConsultationService:
+    return _consultation_service
+
+
+def get_consultation_store():
+    return _consultation_store
+
+
 def get_line_token_manager() -> LineTokenManager:
     return _line_token_manager
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -27,6 +27,13 @@ from app.services.family.family_tree_service import FamilyTreeService
 from app.services.liff.auth_service import LiffAuthApplicationService
 from app.services.liff.jwt_service import AppJwtService
 from app.services.liff.line_id_token_service import LineIdTokenService
+from app.repositories.consultation_repository import ConsultationRepository
+from app.services.consultation.proxies import (
+    ConsultationAwareAgent,
+    ConsultationAwareLineMessageService,
+)
+from app.services.consultation.consultation_service import ConsultationService
+from app.services.consultation.store import build_consultation_store
 
 _mongodb_url = os.getenv("MONGODB_URL")
 MongoDBManager.configure(_mongodb_url or settings.MONGODB_URI)

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app.routers.users.upsert_users import router as profile_router
 from app.core.cors import add_cors_middleware
 from app.core.config import settings
 from app.dependencies import get_consultation_service, get_consultation_store
+from app.repositories.consultation_repository import ConsultationRepository
 from app.services.consultation.scheduler import (
     start_consultation_daily_summary_scheduler,
 )
@@ -21,6 +22,9 @@ logging.basicConfig(level=logging.INFO)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # FastAPI lifespan 會在 yield 前執行 startup 邏輯。
+    # 先確認 MongoDB 摘要 collection 有 TTL index，讓摘要只保留 7 天。
+    await ConsultationRepository.ensure_indexes()
+
     # 這裡啟動每日諮詢摘要排程，讓它在背景 task 中持續等待下一次執行時間。
     scheduler = start_consultation_daily_summary_scheduler(
         enabled=True,  # 啟動自動排程

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,11 @@ from app.routers.liff.auth import router as auth_router
 from app.routers.system import router as system_router
 from app.routers.users.upsert_users import router as profile_router
 from app.core.cors import add_cors_middleware
+from app.core.config import settings
+from app.dependencies import get_consultation_service, get_consultation_store
+from app.services.consultation.scheduler import (
+    start_consultation_daily_summary_scheduler,
+)
 
 from app.routers.family_tree import router as family_tree_router
 
@@ -16,6 +21,17 @@ app = FastAPI(
     description="CARE 系統後端 API (包含 LINE Bot Webhook 與 LIFF REST API)",
     version="1.0.0",
 )
+
+
+@app.on_event("startup")
+async def start_up_event() -> None:
+    start_consultation_daily_summary_scheduler(
+        enabled=True,  # 啟動自動排程
+        run_time=settings.CONSULTATION_DAILY_SUMMARY_TIME,
+        consultation_service=get_consultation_service(),
+        consultation_store=get_consultation_store(),
+    )
+
 
 # Centralized CORS config
 add_cors_middleware(app)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from app.routers.line.webhook import router as line_router
@@ -16,21 +17,33 @@ from app.routers.family_tree import router as family_tree_router
 
 logging.basicConfig(level=logging.INFO)
 
-app = FastAPI(
-    title="CARE Backend API",
-    description="CARE 系統後端 API (包含 LINE Bot Webhook 與 LIFF REST API)",
-    version="1.0.0",
-)
 
-
-@app.on_event("startup")
-async def start_up_event() -> None:
-    start_consultation_daily_summary_scheduler(
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # FastAPI lifespan 會在 yield 前執行 startup 邏輯。
+    # 這裡啟動每日諮詢摘要排程，讓它在背景 task 中持續等待下一次執行時間。
+    scheduler = start_consultation_daily_summary_scheduler(
         enabled=True,  # 啟動自動排程
         run_time=settings.CONSULTATION_DAILY_SUMMARY_TIME,
         consultation_service=get_consultation_service(),
         consultation_store=get_consultation_store(),
     )
+    try:
+        # yield 期間代表 app 正在運行並處理 requests。
+        # 當 app 關閉時，FastAPI 會離開這個 yield，繼續執行 finally 清理邏輯。
+        yield
+    finally:
+        # shutdown 時取消背景排程 task
+        if scheduler is not None:
+            await scheduler.stop()
+
+
+app = FastAPI(
+    title="CARE Backend API",
+    description="CARE 系統後端 API (包含 LINE Bot Webhook 與 LIFF REST API)",
+    version="1.0.0",
+    lifespan=lifespan,
+)
 
 
 # Centralized CORS config

--- a/app/models/consultation.py
+++ b/app/models/consultation.py
@@ -1,0 +1,38 @@
+# 定義諮詢對話相關的 Pydantic 模型
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ConsultationMessage(BaseModel):
+    line_id: str = Field(..., description="LINE user ID")
+    message_type: str = Field(..., description="訊息類型，例如 text / location / image")
+    content: str = Field(..., description="可供摘要與顯示的訊息內容")
+    raw_text: Optional[str] = Field(default=None, description="原始文字或原始媒體描述")
+    timestamp: datetime = Field(..., description="UTC timestamp")
+
+
+class ConsultationSummary(BaseModel):
+    line_id: str = Field(..., description="LINE user ID")
+    summary_date: date = Field(..., description="摘要日期")
+    summary: str = Field(..., description="摘要內容")
+    created_at: datetime = Field(..., description="建立時間")
+
+
+class ConsultationSummarizeRequest(BaseModel):
+    target_date: Optional[date] = Field(default=None, description="要摘要的日期")
+    force: bool = Field(default=False, description="是否強制重新摘要")
+
+
+class ConsultationViewResponse(BaseModel):
+    """諮詢紀錄查詢回傳"""
+
+    line_id: str = Field(..., description="LINE user ID")
+    view_type: Literal["summary", "raw"] = Field(..., description="回傳資料來源")
+    summary: Optional[str] = Field(default=None, description="摘要內容")
+    messages: list[ConsultationMessage] = Field(
+        default_factory=list, description="原始對話訊息"
+    )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -27,12 +27,6 @@ class UserProfileData(BaseModel):
     major_illness_history: str = Field(..., description="Major illness history")
     surgery_history: str = Field(..., description="Surgery history")
 
-    # 健康諮詢記錄使用 JSON 物件，預設空 dict
-    health_consultations: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Health consultation records in JSON format",
-    )
-
 
 # 這裡userprofile繼承userprofiledata，並且加上line_id、created_at、updated_at等欄位
 class UserProfile(UserProfileData):

--- a/app/repositories/consultation_repository.py
+++ b/app/repositories/consultation_repository.py
@@ -51,14 +51,21 @@ class ConsultationRepository:
     @staticmethod
     async def get_latest_summary(line_id: str) -> Optional[ConsultationSummary]:
         collection = MongoDBManager.get_consultation_summaries_collection()
-        document = (
-            await collection.find({"line_id": line_id})
-            .sort("summary_date", -1)
-            .limit(1)
-            .to_list(length=1)
-        )
+        cursor = collection.find({"line_id": line_id}).sort("summary_date", -1)
+        document = await cursor.limit(1).to_list(length=1)
         if not document:
             return None
         latest = document[0]
         latest.pop("_id", None)
         return ConsultationSummary.model_validate(latest)
+
+    @staticmethod
+    async def get_all_summaries(line_id: str) -> list[ConsultationSummary]:
+        collection = MongoDBManager.get_consultation_summaries_collection()
+        cursor = collection.find({"line_id": line_id}).sort("summary_date", -1)
+        documents = await cursor.to_list(length=None)
+        summaries: list[ConsultationSummary] = []
+        for document in documents:
+            document.pop("_id", None)
+            summaries.append(ConsultationSummary.model_validate(document))
+        return summaries

--- a/app/repositories/consultation_repository.py
+++ b/app/repositories/consultation_repository.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Optional
+
+from app.db.mongodb import MongoDBManager
+from app.models.consultation import ConsultationSummary
+
+SUMMARY_TTL_SECONDS = 7 * 24 * 60 * 60  # TTL設定一周
+
+
+class ConsultationRepository:
+    @staticmethod
+    async def ensure_indexes() -> None:
+        collection = MongoDBManager.get_consultation_summaries_collection()
+        await collection.create_index(
+            [("created_at", 1)],
+            expireAfterSeconds=SUMMARY_TTL_SECONDS,
+            name="consultation_summary_created_at_ttl",
+        )
+
+    @staticmethod
+    async def upsert_summary(summary: ConsultationSummary) -> ConsultationSummary:
+        collection = MongoDBManager.get_consultation_summaries_collection()
+        payload = summary.model_dump(mode="json")
+        payload["created_at"] = summary.created_at
+
+        await collection.update_one(
+            {
+                "line_id": summary.line_id,
+                "summary_date": summary.summary_date.isoformat(),
+            },
+            {"$set": payload},
+            upsert=True,
+        )
+        return summary
+
+    @staticmethod
+    async def get_summary(
+        line_id: str, target_date: date
+    ) -> Optional[ConsultationSummary]:
+        collection = MongoDBManager.get_consultation_summaries_collection()
+        document = await collection.find_one(
+            {"line_id": line_id, "summary_date": target_date.isoformat()}
+        )
+        if not document:
+            return None
+        document.pop("_id", None)
+        return ConsultationSummary.model_validate(document)
+
+    @staticmethod
+    async def get_latest_summary(line_id: str) -> Optional[ConsultationSummary]:
+        collection = MongoDBManager.get_consultation_summaries_collection()
+        document = (
+            await collection.find({"line_id": line_id})
+            .sort("summary_date", -1)
+            .limit(1)
+            .to_list(length=1)
+        )
+        if not document:
+            return None
+        latest = document[0]
+        latest.pop("_id", None)
+        return ConsultationSummary.model_validate(latest)

--- a/app/routers/users/consultations.py
+++ b/app/routers/users/consultations.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pymongo.errors import PyMongoError
 from redis.exceptions import RedisError
-
-from app.dependencies import CurrentUser, get_consultation_service, get_current_user
+from datetime import date
+from fastapi.responses import JSONResponse
+from app.dependencies import (
+    CurrentUser,
+    get_consultation_service,
+    get_current_user,
+    get_consultation_store,
+)
 from app.models.consultation import (
     ConsultationSummarizeRequest,
     ConsultationViewResponse,
@@ -20,7 +26,7 @@ router = APIRouter(tags=["Consultation"])
     "/me",
     response_model=ConsultationViewResponse,
     summary="取得目前使用者諮詢紀錄",
-    description="優先回傳摘要，若今天尚未產生摘要則回傳原始對話。",
+    description="優先回傳最新的摘要，如果沒有摘要則回傳原始對話。",
 )
 async def get_my_consultations(
     current_user: CurrentUser = Depends(get_current_user),
@@ -43,7 +49,9 @@ async def get_today_consultations(
     consultation_service: ConsultationService = Depends(get_consultation_service),
 ):
     try:
-        return await consultation_service.get_view(current_user.line_user_id)
+        return await consultation_service.get_view(
+            current_user.line_user_id, date.today()
+        )
     except (RedisError, PyMongoError):
         raise HTTPException(status_code=503, detail="資料庫連線異常，請稍後再試")
 
@@ -62,6 +70,22 @@ async def get_raw_consultations(
         return await consultation_service.get_raw_view(current_user.line_user_id)
     except RedisError:
         raise HTTPException(status_code=503, detail="Redis 連線異常，請稍後再試")
+
+
+@router.get(
+    "/me/allsummaries",
+    response_model=list[ConsultationSummary],
+    summary="取得目前使用者所有摘要紀錄",
+    description="直接回傳目前登入使用者在 MongoDB 中的所有諮詢摘要，依日期由新到舊排序。",
+)
+async def get_my_summary_history(
+    current_user: CurrentUser = Depends(get_current_user),
+    consultation_service: ConsultationService = Depends(get_consultation_service),
+):
+    try:
+        return await consultation_service.get_all_summaries(current_user.line_user_id)
+    except PyMongoError:
+        raise HTTPException(status_code=503, detail="MongoDB 連線異常，請稍後再試")
 
 
 @router.post(

--- a/app/routers/users/consultations.py
+++ b/app/routers/users/consultations.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pymongo.errors import PyMongoError
+from redis.exceptions import RedisError
+
+from app.dependencies import CurrentUser, get_consultation_service, get_current_user
+from app.models.consultation import (
+    ConsultationSummarizeRequest,
+    ConsultationViewResponse,
+    ConsultationSummary,
+)
+from app.services.consultation.consultation_service import ConsultationService
+from app.infrastructure.gemini.shared.errors import GeminiHttpError
+
+router = APIRouter(tags=["Consultation"])
+
+
+@router.get(
+    "/me",
+    response_model=ConsultationViewResponse,
+    summary="取得目前使用者諮詢紀錄",
+    description="優先回傳摘要，若今天尚未產生摘要則回傳原始對話。",
+)
+async def get_my_consultations(
+    current_user: CurrentUser = Depends(get_current_user),
+    consultation_service: ConsultationService = Depends(get_consultation_service),
+):
+    try:
+        return await consultation_service.get_view(current_user.line_user_id)
+    except (RedisError, PyMongoError):
+        raise HTTPException(status_code=503, detail="資料庫連線異常，請稍後再試")
+
+
+@router.get(
+    "/me/today",
+    response_model=ConsultationViewResponse,
+    summary="取得今天的諮詢紀錄",
+    description="回傳今天的摘要或原始對話。",
+)
+async def get_today_consultations(
+    current_user: CurrentUser = Depends(get_current_user),
+    consultation_service: ConsultationService = Depends(get_consultation_service),
+):
+    try:
+        return await consultation_service.get_view(current_user.line_user_id)
+    except (RedisError, PyMongoError):
+        raise HTTPException(status_code=503, detail="資料庫連線異常，請稍後再試")
+
+
+@router.get(
+    "/me/raw",
+    response_model=ConsultationViewResponse,
+    summary="取得原始諮詢快取",
+    description="直接回傳 Redis 內的原始對話。",
+)
+async def get_raw_consultations(
+    current_user: CurrentUser = Depends(get_current_user),
+    consultation_service: ConsultationService = Depends(get_consultation_service),
+):
+    try:
+        return await consultation_service.get_raw_view(current_user.line_user_id)
+    except RedisError:
+        raise HTTPException(status_code=503, detail="Redis 連線異常，請稍後再試")
+
+
+@router.post(
+    "/me/summarize",
+    response_model=ConsultationSummary,
+    summary="手動摘要諮詢紀錄",
+    description="把指定日期或今天的對話摘要後寫入 MongoDB。",
+)
+async def summarize_consultations(
+    request: ConsultationSummarizeRequest,
+    current_user: CurrentUser = Depends(get_current_user),
+    consultation_service: ConsultationService = Depends(get_consultation_service),
+):
+    try:
+        return await consultation_service.summarize(current_user.line_user_id, request)
+    except GeminiHttpError as exc:
+        if exc.status_code == 429:
+            raise HTTPException(status_code=429, detail="AI 額度已達上限，請稍後再試")
+        raise HTTPException(status_code=502, detail=str(exc))
+    except RedisError:
+        raise HTTPException(status_code=503, detail="Redis 連線異常，請稍後再試")
+    except PyMongoError:
+        raise HTTPException(status_code=503, detail="MongoDB 連線異常，請稍後再試")

--- a/app/services/consultation/consultation_service.py
+++ b/app/services/consultation/consultation_service.py
@@ -67,9 +67,7 @@ class ConsultationService:
             raw_text=raw_text,
             timestamp=context.event_time or datetime.now(timezone.utc),
         )
-        await self._store.append_message(
-            context.line_id, message.timestamp.date(), message
-        )
+        await self._store.append_message(context.line_id, message)
         return ConsultationRecordResult(stored=True)
 
     # 負責記錄agent的回覆訊息，邏輯與 record_user_message 類似，但訊息類型固定為
@@ -88,18 +86,31 @@ class ConsultationService:
             raw_text=assistant_text,
             timestamp=datetime.now(timezone.utc),
         )
-        await self._store.append_message(
-            context.line_id, message.timestamp.date(), message
-        )
+        await self._store.append_message(context.line_id, message)
         return ConsultationRecordResult(stored=True)
 
-    # 這裡的 get_view 方法會優先嘗試從 repository 取得摘要，如果沒有摘要才會
+    # 這裡的 get_view 方法會優先嘗試從 repository 取得最新的摘要，如果沒有摘要才會
     # 從 store 取得原始訊息列表。
+
     async def get_view(
         self, user_id: str, target_date: Optional[date] = None
     ) -> ConsultationViewResponse:
-        target = target_date or date.today()
-        summary = await self._repository.get_summary(user_id, target)
+        if target_date is None:
+            summary = await self._repository.get_latest_summary(user_id)
+            if summary is not None:
+                return ConsultationViewResponse(
+                    line_id=user_id,
+                    view_type="summary",
+                    summary=summary.summary,
+                )
+
+            return ConsultationViewResponse(
+                line_id=user_id,
+                view_type="summary",
+                summary=None,
+            )
+
+        summary = await self._repository.get_summary(user_id, target_date)
         if summary is not None:
             return ConsultationViewResponse(
                 line_id=user_id,
@@ -107,36 +118,49 @@ class ConsultationService:
                 summary=summary.summary,
             )
 
-        messages = await self._store.list_messages(user_id, target)
         return ConsultationViewResponse(
             line_id=user_id,
-            view_type="raw",
-            messages=messages,
+            view_type="summary",
+            summary=None,
         )
 
     # get_raw_view 方法則是直接從 store 取得原始訊息列表，不考慮是否有摘要。
     async def get_raw_view(
         self, user_id: str, target_date: Optional[date] = None
     ) -> ConsultationViewResponse:
-        target = target_date or date.today()
-        messages = await self._store.list_messages(user_id, target)
+        messages = await self._store.list_messages(user_id)
+        if target_date is not None:
+            messages = [
+                message
+                for message in messages
+                if message.timestamp.date() == target_date
+            ]
         return ConsultationViewResponse(
             line_id=user_id,
             view_type="raw",
             messages=messages,
         )
 
-    # summarize 方法會根據指定的日期或是當天從 store 取得原始訊息列表，
+    async def get_all_summaries(self, user_id: str) -> list[ConsultationSummary]:
+        return await self._repository.get_all_summaries(user_id)
+
+    # summarize 方法會直接從 store 取得目前使用者的完整對話列表，
     # 然後使用 Gemini 生成摘要，最後將摘要存到 repository。
     async def summarize(
         self, user_id: str, request: ConsultationSummarizeRequest
     ) -> ConsultationSummary:
-        target_date = request.target_date or date.today()
+        messages = await self._store.list_messages(user_id)
+
+        if messages:
+            latest_message = max(messages, key=lambda message: message.timestamp)
+            target_date = latest_message.timestamp.date()
+        else:
+            target_date = date.today()
+
         existing = await self._repository.get_summary(user_id, target_date)
         if existing is not None and not request.force:
             return existing
 
-        messages = await self._store.list_messages(user_id, target_date)
         # 調用內部方法 _generate_summary 來產生摘要
         summary_text = await self._generate_summary(user_id, target_date, messages)
         summary = ConsultationSummary(
@@ -152,7 +176,7 @@ class ConsultationService:
     async def summarize_today_if_needed(
         self, user_id: str
     ) -> Optional[ConsultationSummary]:
-        messages = await self._store.list_messages(user_id, date.today())
+        messages = await self._store.list_messages(user_id)
         if not messages:
             return None
         return await self.summarize(user_id, ConsultationSummarizeRequest())
@@ -195,7 +219,7 @@ class ConsultationService:
         self, user_id: str, target_date: date, messages: list[ConsultationMessage]
     ) -> str:
         if not messages:
-            return "今日尚無諮詢記錄。"
+            return "該日期尚無諮詢記錄。"
 
         transcript_lines = []
         for message in messages:
@@ -215,4 +239,4 @@ class ConsultationService:
             raise_mapped_gemini_error(exc)
         content = getattr(result, "content", "")
         summary_text = str(content).strip()
-        return summary_text or "今日尚無可摘要內容。"
+        return summary_text or "該日期尚無可摘要內容。"

--- a/app/services/consultation/consultation_service.py
+++ b/app/services/consultation/consultation_service.py
@@ -1,0 +1,219 @@
+# 諮詢功能的核心服務，負責處理諮詢訊息的記錄、摘要生成和搜尋等邏輯。
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Optional
+from app.models.consultation import (
+    ConsultationMessage,
+    ConsultationSummarizeRequest,
+    ConsultationSummary,
+    ConsultationViewResponse,
+)
+from app.repositories.consultation_repository import ConsultationRepository
+from app.services.consultation.context import (
+    ConsultationContext,
+    get_current_consultation_context,
+)
+from app.services.consultation.store import ConsultationStore
+from app.infrastructure.gemini import GeminiService
+from app.infrastructure.gemini.shared.errors import raise_mapped_gemini_error
+
+
+@dataclass(frozen=True)
+class ConsultationRecordResult:
+    stored: bool
+
+
+class ConsultationService:
+    def __init__(
+        self,
+        *,
+        # store是儲存對話訊息的抽象介面，實際上由 RedisConsultationStore 實作
+        store: ConsultationStore,
+        # repository是儲存諮詢摘要的抽象介面，實際上由 MongoDBConsultationRepository 實作
+        repository: ConsultationRepository,
+        # 用來生成最後摘要
+        gemini_service: GeminiService,
+    ) -> None:
+        self._store = store
+        self._repository = repository
+        self._gemini_service = gemini_service
+
+    # record_user_message負責記錄使用者的訊息，從當前的 ConsultationContext
+    # 取得必要資訊， 然後將訊息封裝成 ConsultationMessage 並存入 store。
+    async def record_user_message(self, user_input: str) -> ConsultationRecordResult:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        context = get_current_consultation_context()
+        logger.info(
+            f"[ConsultationService.record_user_message] context={context}, line_id={context.line_id if context else None}"
+        )
+        if context is None or not context.line_id:
+            logger.warning(
+                f"[ConsultationService.record_user_message] 失敗：context 或 line_id 為空"
+            )
+            return ConsultationRecordResult(stored=False)
+
+        raw_text = self._normalize_raw_text(
+            context.message_type, context.raw_message, user_input
+        )
+
+        message = ConsultationMessage(
+            line_id=context.line_id,
+            message_type=context.message_type,
+            content=user_input,
+            raw_text=raw_text,
+            ai_analyzed_text=user_input if context.message_type != "text" else None,
+            timestamp=context.event_time or datetime.now(timezone.utc),
+        )
+        await self._store.append_message(
+            context.line_id, message.timestamp.date(), message
+        )
+        return ConsultationRecordResult(stored=True)
+
+    # 負責記錄agent的回覆訊息，邏輯與 record_user_message 類似，但訊息類型固定為
+    # "assistant_reply"。
+    async def record_assistant_message(
+        self, assistant_text: str
+    ) -> ConsultationRecordResult:
+        context = get_current_consultation_context()
+        if context is None or not context.line_id:
+            return ConsultationRecordResult(stored=False)
+
+        message = ConsultationMessage(
+            line_id=context.line_id,
+            message_type="assistant_reply",
+            content=assistant_text,
+            raw_text=assistant_text,
+            timestamp=datetime.now(timezone.utc),
+        )
+        await self._store.append_message(
+            context.line_id, message.timestamp.date(), message
+        )
+        return ConsultationRecordResult(stored=True)
+
+    # 這裡的 get_view 方法會優先嘗試從 repository 取得摘要，如果沒有摘要才會
+    # 從 store 取得原始訊息列表。
+    async def get_view(
+        self, user_id: str, target_date: Optional[date] = None
+    ) -> ConsultationViewResponse:
+        target = target_date or date.today()
+        summary = await self._repository.get_summary(user_id, target)
+        if summary is not None:
+            return ConsultationViewResponse(
+                line_id=user_id,
+                view_type="summary",
+                summary=summary.summary,
+            )
+
+        messages = await self._store.list_messages(user_id, target)
+        return ConsultationViewResponse(
+            line_id=user_id,
+            view_type="raw",
+            messages=messages,
+        )
+
+    # get_raw_view 方法則是直接從 store 取得原始訊息列表，不考慮是否有摘要。
+    async def get_raw_view(
+        self, user_id: str, target_date: Optional[date] = None
+    ) -> ConsultationViewResponse:
+        target = target_date or date.today()
+        messages = await self._store.list_messages(user_id, target)
+        return ConsultationViewResponse(
+            line_id=user_id,
+            view_type="raw",
+            messages=messages,
+        )
+
+    # summarize 方法會根據指定的日期或是當天從 store 取得原始訊息列表，
+    # 然後使用 Gemini 生成摘要，最後將摘要存到 repository。
+    async def summarize(
+        self, user_id: str, request: ConsultationSummarizeRequest
+    ) -> ConsultationSummary:
+        target_date = request.target_date or date.today()
+        existing = await self._repository.get_summary(user_id, target_date)
+        if existing is not None and not request.force:
+            return existing
+
+        messages = await self._store.list_messages(user_id, target_date)
+        # 調用內部方法 _generate_summary 來產生摘要
+        summary_text = await self._generate_summary(user_id, target_date, messages)
+        summary = ConsultationSummary(
+            line_id=user_id,
+            summary_date=target_date,
+            summary=summary_text,
+            created_at=datetime.now(timezone.utc),
+        )
+        await self._repository.upsert_summary(summary)
+        return summary
+
+    # 用來檢查今天是否已經有摘要，如果沒有就自動生成。
+    async def summarize_today_if_needed(
+        self, user_id: str
+    ) -> Optional[ConsultationSummary]:
+        messages = await self._store.list_messages(user_id, date.today())
+        if not messages:
+            return None
+        return await self.summarize(user_id, ConsultationSummarizeRequest())
+
+    @staticmethod
+    def _normalize_raw_text(
+        message_type: str, raw_message: Optional[object], fallback: str
+    ) -> str:
+        """根據訊息類型從原始 message 物件提取並格式化 raw_text。
+
+        Args:
+            message_type: LINE 訊息類型 (text, location, image, video, audio, file 等)
+            raw_message: LINE message 物件
+            fallback: 若無法提取時的預設值（通常是 user_input 或 assistant_text）
+
+        Returns:
+            格式化後的 raw_text 字串
+        """
+        if raw_message is None:
+            return fallback
+
+        if message_type == "text":
+            return getattr(raw_message, "text", fallback)
+        elif message_type == "location":
+            lat = getattr(raw_message, "latitude", "")
+            lng = getattr(raw_message, "longitude", "")
+            return f"lat={lat}, lng={lng}" if lat or lng else fallback
+        elif message_type == "file":
+            file_name = getattr(raw_message, "file_name", None)
+            media_id = getattr(raw_message, "id", None)
+            return file_name or media_id or fallback
+        elif message_type in {"image", "video", "audio"}:
+            media_id = getattr(raw_message, "id", None)
+            return media_id or fallback
+        else:
+            return fallback
+
+    # 真正呼叫gemini做摘要
+    async def _generate_summary(
+        self, user_id: str, target_date: date, messages: list[ConsultationMessage]
+    ) -> str:
+        if not messages:
+            return "今日尚無諮詢記錄。"
+
+        transcript_lines = []
+        for message in messages:
+            transcript_lines.append(f"[{message.message_type}] {message.content}")
+
+        prompt = (
+            "你是醫療諮詢紀錄整理助手。請根據以下對話整理成簡潔的中文摘要，"
+            "保留症狀、檢查、建議與重要時間點，避免冗長。\n\n"
+            f"使用者：{user_id}\n"
+            f"日期：{target_date.isoformat()}\n"
+            "對話內容：\n" + "\n".join(transcript_lines)
+        )
+
+        try:
+            result = await self._gemini_service._chat_llm.ainvoke(prompt)
+        except Exception as exc:
+            raise_mapped_gemini_error(exc)
+        content = getattr(result, "content", "")
+        summary_text = str(content).strip()
+        return summary_text or "今日尚無可摘要內容。"

--- a/app/services/consultation/consultation_service.py
+++ b/app/services/consultation/consultation_service.py
@@ -65,7 +65,6 @@ class ConsultationService:
             message_type=context.message_type,
             content=user_input,
             raw_text=raw_text,
-            ai_analyzed_text=user_input if context.message_type != "text" else None,
             timestamp=context.event_time or datetime.now(timezone.utc),
         )
         await self._store.append_message(

--- a/app/services/consultation/proxies.py
+++ b/app/services/consultation/proxies.py
@@ -1,0 +1,48 @@
+# 包裝原本的agent 和 line message service，讓它們在處理訊息的同時也能記錄到
+# consultation service 中。
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from app.services.consultation.consultation_service import ConsultationService
+
+
+# 這裡定義了一些代理類別，用來包裝原本的 agent 和 line message service
+class ConsultationAwareAgent:
+    def __init__(self, agent: Any, consultation_service: ConsultationService) -> None:
+        self._agent = agent
+        self._consultation_service = consultation_service
+
+    async def invoke(self, user_input: str) -> dict:
+        # 先把使用者輸入記錄到 consultation service
+        from app.services.consultation.context import get_current_consultation_context
+
+        ctx = get_current_consultation_context()
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.info(
+            f"[ConsultationAwareAgent] 開始呼叫 record_user_message，line_id={ctx.line_id if ctx else None}"
+        )
+        await self._consultation_service.record_user_message(user_input)
+        # 再調用原本的 agent 來獲取回覆
+        return await self._agent.invoke(user_input=user_input)
+
+
+class ConsultationAwareLineMessageService:
+    def __init__(self, service: Any, consultation_service: ConsultationService) -> None:
+        self._service = service
+        self._consultation_service = consultation_service
+
+    async def send_line_reply(
+        self, reply_token: str, message_text: str, user_id: Optional[str] = None
+    ) -> bool:
+        success = await self._service.send_line_reply(
+            reply_token, message_text, user_id
+        )
+        if success:
+            await self._consultation_service.record_assistant_message(message_text)
+        return success
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._service, item)

--- a/app/services/consultation/scheduler.py
+++ b/app/services/consultation/scheduler.py
@@ -1,0 +1,90 @@
+# 這是一個每天定時執行的排程，負責對當天有對話記錄的使用者進行摘要
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime, time, timedelta
+
+from app.services.consultation.consultation_service import ConsultationService
+from app.services.consultation.store import ConsultationStore
+
+logger = logging.getLogger(__name__)
+
+
+class ConsultationDailySummaryScheduler:
+    def __init__(
+        self,
+        *,
+        consultation_service: ConsultationService,
+        consultation_store: ConsultationStore,
+        run_time: str,
+    ) -> None:
+        self._consultation_service = consultation_service
+        self._consultation_store = consultation_store
+        self._run_time = run_time
+        self._task: asyncio.Task | None = None
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("[ConsultationDailySummaryScheduler] started")
+
+    async def _run_loop(self) -> None:
+        while True:
+            now = datetime.now()
+            next_run = self._next_run_at(now)
+            wait_seconds = max(0.0, (next_run - now).total_seconds())
+            await asyncio.sleep(wait_seconds)
+            await self._run_once()
+
+    def _next_run_at(self, now: datetime) -> datetime:
+        run_time = self._parse_time(self._run_time)
+        today_target = datetime.combine(now.date(), run_time)
+        if today_target <= now:
+            return today_target + timedelta(days=1)
+        return today_target
+
+    @staticmethod
+    def _parse_time(value: str) -> time:
+        hour_text, minute_text = value.split(":", 1)
+        hour = int(hour_text)
+        minute = int(minute_text)
+        if hour == 24 and minute == 0:  # 特例：24:00 表示隔天的 00:00
+            return time(hour=0, minute=0)
+        return time(hour=hour, minute=minute)
+
+    async def _run_once(self) -> None:
+        target_date = date.today()
+        # 從 Redis 找出今天有對話記錄的 line_id，然後逐一呼叫 summarize_today_if_needed
+        line_ids = await self._consultation_store.list_line_ids_by_date(target_date)
+        if not line_ids:
+            return
+
+        for line_id in line_ids:
+            try:
+                await self._consultation_service.summarize_today_if_needed(line_id)
+            except Exception:
+                logger.exception(
+                    "[ConsultationDailySummaryScheduler] summarize failed, line_id=%s",
+                    line_id,
+                )
+
+
+def start_consultation_daily_summary_scheduler(
+    *,
+    enabled: bool,
+    run_time: str,
+    consultation_service: ConsultationService,
+    consultation_store: ConsultationStore,
+) -> None:
+    if not enabled:
+        logger.info("[ConsultationDailySummaryScheduler] disabled")
+        return
+
+    scheduler = ConsultationDailySummaryScheduler(
+        consultation_service=consultation_service,
+        consultation_store=consultation_store,
+        run_time=run_time,
+    )
+    scheduler.start()

--- a/app/services/consultation/scheduler.py
+++ b/app/services/consultation/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import suppress
 from datetime import date, datetime, time, timedelta
 
 from app.services.consultation.consultation_service import ConsultationService
@@ -27,14 +28,33 @@ class ConsultationDailySummaryScheduler:
     def start(self) -> None:
         if self._task is not None and not self._task.done():
             return
+        # 建立背景 task；呼叫端不需要等待它完成，排程會自己在 _run_loop 中循環。
         self._task = asyncio.create_task(self._run_loop())
-        logger.info("[ConsultationDailySummaryScheduler] started")
+        logger.info(
+            "[ConsultationDailySummaryScheduler] started, run_time=%s",
+            self._run_time,
+        )
+
+    async def stop(self) -> None:
+        if self._task is None or self._task.done():
+            return
+        # app shutdown 時取消 sleep 中或執行中的背景 task，並吞掉預期中的 CancelledError。
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+        logger.info("[ConsultationDailySummaryScheduler] stopped")
 
     async def _run_loop(self) -> None:
         while True:
             now = datetime.now()
             next_run = self._next_run_at(now)
             wait_seconds = max(0.0, (next_run - now).total_seconds())
+            # 等到下一次排程時間；執行完 _run_once 後會回到 while True，繼續等待隔天。
+            logger.info(
+                "   [ConsultationDailySummaryScheduler] next_run=%s, wait_seconds=%.1f",
+                next_run.isoformat(timespec="seconds"),
+                wait_seconds,
+            )
             await asyncio.sleep(wait_seconds)
             await self._run_once()
 
@@ -58,8 +78,19 @@ class ConsultationDailySummaryScheduler:
         target_date = date.today()
         # 從 Redis 找出今天有對話記錄的 line_id，然後逐一呼叫 summarize_today_if_needed
         line_ids = await self._consultation_store.list_line_ids_by_date(target_date)
+        # 如果沒有任何 line_id 就直接印出訊息並結束
         if not line_ids:
+            logger.warning(  # 用logger warning，並將文字大寫
+                "[ConsultationDailySummaryScheduler]Attention! NO CONSULTATION RECORDS FOR %s",
+                target_date.isoformat(),
+            )
             return
+
+        logger.info(
+            "[ConsultationDailySummaryScheduler] summarizing %d user(s) for %s",
+            len(line_ids),
+            target_date.isoformat(),
+        )
 
         for line_id in line_ids:
             try:
@@ -71,16 +102,17 @@ class ConsultationDailySummaryScheduler:
                 )
 
 
+# 在main的lifespan中呼叫，yield前的code表示在app啟動時執行，yield後的code表示在app關閉時執行。
 def start_consultation_daily_summary_scheduler(
     *,
     enabled: bool,
     run_time: str,
     consultation_service: ConsultationService,
     consultation_store: ConsultationStore,
-) -> None:
+) -> ConsultationDailySummaryScheduler | None:
     if not enabled:
         logger.info("[ConsultationDailySummaryScheduler] disabled")
-        return
+        return None
 
     scheduler = ConsultationDailySummaryScheduler(
         consultation_service=consultation_service,
@@ -88,3 +120,4 @@ def start_consultation_daily_summary_scheduler(
         run_time=run_time,
     )
     scheduler.start()
+    return scheduler

--- a/app/services/consultation/store.py
+++ b/app/services/consultation/store.py
@@ -1,0 +1,141 @@
+# 負責將諮詢對話訊息存入 Redis，並提供查詢接口給 ConsultationService 使用。
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from typing import Any, Protocol
+
+from app.db.redis import RedisManager
+from app.models.consultation import ConsultationMessage
+
+
+class ConsultationStore(Protocol):
+    """定義諮詢對話訊息存取的抽象介面，
+    讓 `ConsultationService` 能依賴抽象介面而非具體實作，
+    方便後續替換或 mock。
+    """
+
+    async def append_message(
+        self, line_id: str, summary_date: date, message: ConsultationMessage
+    ) -> None: ...
+
+    async def list_messages(
+        self, line_id: str, summary_date: date
+    ) -> list[ConsultationMessage]: ...
+
+    async def list_dates(self, line_id: str) -> list[date]: ...
+
+    async def list_line_ids_by_date(self, summary_date: date) -> list[str]: ...
+
+
+class RedisConsultationStore:
+    """Redis 為主的諮詢對話儲存實作
+
+    責任：
+    - 將使用者訊息和 AI 回覆存入 Redis list，以日期分組
+    - 支援依日期查詢對話列表
+    - 自動設定 1 天 TTL，過期自動清除
+
+    Key 格式：consultationRecord:{line_id}:{date}
+    Value：JSON 陣列，每筆元素是一個 ConsultationMessage
+    """
+
+    def __init__(self, client: Any) -> None:
+        # 初始化 Redis 客戶端。
+        self._client = client
+
+    async def append_message(
+        self, line_id: str, summary_date: date, message: ConsultationMessage
+    ) -> None:
+        """把單一訊息（使用者或 AI 回覆）附加到 Redis list
+
+        實作細節：
+        - 序列化訊息成 JSON 字串，用 rpush 加到 list 尾端
+        - 設定 1 天 TTL，自動過期清除
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+        key = self._build_key(line_id, summary_date)
+        payload = message.model_dump(mode="json")
+        await self._client.rpush(key, json.dumps(payload, ensure_ascii=False))
+        # 設定 TTL 為 1 天
+        await self._client.expire(key, int(timedelta(days=1).total_seconds()))
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.info(
+            f"[RedisConsultationStore] 成功寫入 Redis，key={key}, message_type={message.message_type}"
+        )
+        logger.info(
+            f"[RedisConsultationStore] 成功寫入 Redis，key={key}, message_type={message.message_type}"
+        )
+
+    async def list_messages(
+        self, line_id: str, summary_date: date
+    ) -> list[ConsultationMessage]:
+        """取出指定日期該使用者的所有對話訊息
+
+        實作細節：
+        - 用 lrange 取 Redis list 全部元素（0 到 -1）
+        - 逐筆 JSON 反序列化成 ConsultationMessage
+        """
+        key = self._build_key(line_id, summary_date)
+        raw_items = await self._client.lrange(key, 0, -1)
+        messages: list[ConsultationMessage] = []
+        for raw_item in raw_items:
+            if isinstance(raw_item, bytes):
+                raw_item = raw_item.decode("utf-8")
+            messages.append(ConsultationMessage.model_validate(json.loads(raw_item)))
+        return messages
+
+    async def list_dates(self, line_id: str) -> list[date]:
+        """取出該使用者在 Redis 內有對話記錄的所有日期。
+
+        實作細節：
+        - 用 keys() 掃出所有 consultationRecord:{line_id}:* 的 key
+        - 從 key 尾端解析出日期字串，轉成 date 物件
+        """
+        key_pattern = f"consultationRecord:{line_id}:*"
+        keys = await self._client.keys(key_pattern)
+        dates: list[date] = []
+        for key in keys:
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            date_text = key.rsplit(":", 1)[-1]
+            try:
+                dates.append(date.fromisoformat(date_text))
+            except ValueError:
+                continue
+        return sorted(set(dates))
+
+    async def list_line_ids_by_date(self, summary_date: date) -> list[str]:
+        # 取出指定日期在 Redis 內有對話記錄的所有 line_id，目前每天自動摘要的 scheduler
+        # 會先用它從 Redis 找出今天有對話的使用者，再逐一呼叫摘要，避免對沒有對話的人跑摘要。
+        date_text = summary_date.isoformat()
+        key_pattern = f"consultationRecord:*:{date_text}"
+        keys = await self._client.keys(key_pattern)
+        line_ids: set[str] = set()
+        prefix = "consultationRecord:"
+        suffix = f":{date_text}"
+        for key in keys:
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            if not key.startswith(prefix) or not key.endswith(suffix):
+                continue
+            line_id = key[len(prefix) : -len(suffix)]
+            if line_id:
+                line_ids.add(line_id)
+        return sorted(line_ids)
+
+    @staticmethod
+    def _build_key(line_id: str, summary_date: date) -> str:
+        # 組合 Redis key，格式為 consultationRecord:{line_id}:{date}
+        # redis用 ":" 分隔不同層級的資訊，下方將最終context存在consultationRecord
+        # 下的line_id層下的summary_date層內
+        return f"consultationRecord:{line_id}:{summary_date.isoformat()}"
+
+
+def build_consultation_store() -> RedisConsultationStore:
+    # 建立 Redis 諮詢對話存放器
+    return RedisConsultationStore(RedisManager.get_client())

--- a/app/services/consultation/store.py
+++ b/app/services/consultation/store.py
@@ -16,12 +16,10 @@ class ConsultationStore(Protocol):
     """
 
     async def append_message(
-        self, line_id: str, summary_date: date, message: ConsultationMessage
+        self, line_id: str, message: ConsultationMessage
     ) -> None: ...
 
-    async def list_messages(
-        self, line_id: str, summary_date: date
-    ) -> list[ConsultationMessage]: ...
+    async def list_messages(self, line_id: str) -> list[ConsultationMessage]: ...
 
     async def list_dates(self, line_id: str) -> list[date]: ...
 
@@ -32,11 +30,11 @@ class RedisConsultationStore:
     """Redis 為主的諮詢對話儲存實作
 
     責任：
-    - 將使用者訊息和 AI 回覆存入 Redis list，以日期分組
-    - 支援依日期查詢對話列表
+    - 將使用者訊息和 AI 回覆存入 Redis list，以使用者分組
+    - 支援依訊息時間戳回推日期做查詢
     - 自動設定 1 天 TTL，過期自動清除
 
-    Key 格式：consultationRecord:{line_id}:{date}
+    Key 格式：consultationRecord:{line_id}
     Value：JSON 陣列，每筆元素是一個 ConsultationMessage
     """
 
@@ -44,9 +42,7 @@ class RedisConsultationStore:
         # 初始化 Redis 客戶端。
         self._client = client
 
-    async def append_message(
-        self, line_id: str, summary_date: date, message: ConsultationMessage
-    ) -> None:
+    async def append_message(self, line_id: str, message: ConsultationMessage) -> None:
         """把單一訊息（使用者或 AI 回覆）附加到 Redis list
 
         實作細節：
@@ -56,28 +52,23 @@ class RedisConsultationStore:
         import logging
 
         logger = logging.getLogger(__name__)
-        key = self._build_key(line_id, summary_date)
+        key = self._build_key(line_id)
         payload = message.model_dump(mode="json")
         await self._client.rpush(key, json.dumps(payload, ensure_ascii=False))
         # 設定 TTL 為 1 天
         await self._client.expire(key, int(timedelta(days=1).total_seconds()))
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.info(
             f"[RedisConsultationStore] 成功寫入 Redis，key={key}, message_type={message.message_type}"
         )
 
-    async def list_messages(
-        self, line_id: str, summary_date: date
-    ) -> list[ConsultationMessage]:
-        """取出指定日期該使用者的所有對話訊息
+    async def list_messages(self, line_id: str) -> list[ConsultationMessage]:
+        """取出該使用者目前 Redis 內的所有對話訊息
 
         實作細節：
         - 用 lrange 取 Redis list 全部元素（0 到 -1）
         - 逐筆 JSON 反序列化成 ConsultationMessage
         """
-        key = self._build_key(line_id, summary_date)
+        key = self._build_key(line_id)
         raw_items = await self._client.lrange(key, 0, -1)
         messages: list[ConsultationMessage] = []
         for raw_item in raw_items:
@@ -87,50 +78,38 @@ class RedisConsultationStore:
         return messages
 
     async def list_dates(self, line_id: str) -> list[date]:
-        """取出該使用者在 Redis 內有對話記錄的所有日期。
+        """取出該使用者在 Redis 內所有對話訊息所涵蓋的日期。
 
         實作細節：
-        - 用 keys() 掃出所有 consultationRecord:{line_id}:* 的 key
-        - 從 key 尾端解析出日期字串，轉成 date 物件
+        - 直接讀取該使用者的完整對話列表
+        - 從每筆訊息的 timestamp 取出日期
         """
-        key_pattern = f"consultationRecord:{line_id}:*"
-        keys = await self._client.keys(key_pattern)
         dates: list[date] = []
-        for key in keys:
-            if isinstance(key, bytes):
-                key = key.decode("utf-8")
-            date_text = key.rsplit(":", 1)[-1]
-            try:
-                dates.append(date.fromisoformat(date_text))
-            except ValueError:
-                continue
+        for message in await self.list_messages(line_id):
+            dates.append(message.timestamp.date())
         return sorted(set(dates))
 
     async def list_line_ids_by_date(self, summary_date: date) -> list[str]:
-        # 取出指定日期在 Redis 內有對話記錄的所有 line_id，目前每天自動摘要的 scheduler
-        # 會先用它從 Redis 找出今天有對話的使用者，再逐一呼叫摘要，避免對沒有對話的人跑摘要。
-        date_text = summary_date.isoformat()
-        key_pattern = f"consultationRecord:*:{date_text}"
+        # 現在 Redis 只按 user 分組，這裡回傳目前仍在 TTL 內的所有 user key。
+        # summary_date 先保留作為相容參數，實際上不再參與過濾。
+        key_pattern = "consultationRecord:*"
         keys = await self._client.keys(key_pattern)
         line_ids: set[str] = set()
         prefix = "consultationRecord:"
-        suffix = f":{date_text}"
         for key in keys:
             if isinstance(key, bytes):
                 key = key.decode("utf-8")
-            if not key.startswith(prefix) or not key.endswith(suffix):
+            if not key.startswith(prefix):
                 continue
-            line_id = key[len(prefix) : -len(suffix)]
+            line_id = key[len(prefix) :]
             if line_id:
                 line_ids.add(line_id)
         return sorted(line_ids)
 
     @staticmethod
-    def _build_key(line_id: str, summary_date: date) -> str:
-        # 組合 Redis key，格式為 consultationRecord:{line_id}:{date}
-        # redis用 ":" 分隔不同層級的資訊，下方將最終context存在consultationRecord
-        # 下的line_id層下的summary_date層內
-        return f"consultationRecord:{line_id}:{summary_date.isoformat()}"
+    def _build_key(line_id: str) -> str:
+        # 組合 Redis key，格式為 consultationRecord:{line_id}
+        return f"consultationRecord:{line_id}"
 
 
 def build_consultation_store() -> RedisConsultationStore:

--- a/app/services/consultation/store.py
+++ b/app/services/consultation/store.py
@@ -67,9 +67,6 @@ class RedisConsultationStore:
         logger.info(
             f"[RedisConsultationStore] 成功寫入 Redis，key={key}, message_type={message.message_type}"
         )
-        logger.info(
-            f"[RedisConsultationStore] 成功寫入 Redis，key={key}, message_type={message.message_type}"
-        )
 
     async def list_messages(
         self, line_id: str, summary_date: date

--- a/app/services/line_messaging/event_handler.py
+++ b/app/services/line_messaging/event_handler.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Optional, cast
+from datetime import datetime, timezone
 from linebot.v3.webhooks import (
     MessageEvent,
     TextMessageContent,
@@ -47,16 +48,26 @@ class LineEventHandler:
 
     async def handle(self, event: MessageEvent) -> None:
         """對外進入點"""
+
+        # thug新增部分 debug用的，line的timestamp是以毫秒為單位的UNIX時間戳，轉換成datetime
+        # 物件時要除以1000並指定時區
+        event_time = datetime.fromtimestamp(event.timestamp / 1000, tz=timezone.utc)
+        logger.info(
+            f"[LineEventHandler.handle] event.source 類型={type(event.source)}, 完整物件={event.source}"
+        )
         user_id = getattr(event.source, "user_id", None)
+        logger.info(f"[LineEventHandler.handle] 從 getattr 取得 user_id={user_id}")
         validate_reply_context(event.reply_token, user_id)
 
         reply_token = event.reply_token
         message = event.message
 
         if isinstance(message, TextMessageContent):
-            await self._handle_text_message(message, reply_token, user_id)
+            await self._handle_text_message(message, reply_token, user_id, event_time)
         elif isinstance(message, LocationMessageContent):
-            await self._handle_location_message(message, reply_token, user_id)
+            await self._handle_location_message(
+                message, reply_token, user_id, event_time
+            )
         elif isinstance(
             message,
             (
@@ -66,12 +77,16 @@ class LineEventHandler:
                 FileMessageContent,
             ),
         ):
-            await self._handle_media_message(message, reply_token, user_id)
+            await self._handle_media_message(message, reply_token, user_id, event_time)
         else:
             logger.warning(f"Unsupported message type: {type(message).__name__}")
 
     async def _handle_text_message(
-        self, message: TextMessageContent, reply_token: str, user_id: Optional[str]
+        self,
+        message: TextMessageContent,
+        reply_token: str,
+        user_id: Optional[str],
+        event_time: datetime,
     ) -> None:
         """處理文字訊息"""
         logger.info(f"Received text message event from user {user_id}")
@@ -81,10 +96,19 @@ class LineEventHandler:
             user_text=user_text,
             reply_token=reply_token,
             user_id=user_id,
+            # thug新增部分：將原始 message 物件也放入 context，讓下游服務
+            # 可以根據需要取用更多細節
+            raw_message=message,
+            message_type="text",
+            event_time=event_time,
         )
 
     async def _handle_location_message(
-        self, message: LocationMessageContent, reply_token: str, user_id: Optional[str]
+        self,
+        message: LocationMessageContent,
+        reply_token: str,
+        user_id: Optional[str],
+        event_time: datetime,
     ) -> None:
         """處理位置訊息"""
         lat: float = message.latitude
@@ -99,10 +123,13 @@ class LineEventHandler:
             user_text=location_text,
             reply_token=reply_token,
             user_id=user_id,
+            raw_message=message,
+            message_type="location",
+            event_time=event_time,
         )
 
     async def _handle_media_message(
-        self, message, reply_token: str, user_id: Optional[str]
+        self, message, reply_token: str, user_id: Optional[str], event_time: datetime
     ) -> None:
         """處理多媒體訊息"""
         media_id = message.id
@@ -129,6 +156,9 @@ class LineEventHandler:
             user_text=f"以下為用戶傳送的{media_type}媒體內容：\n{media_content}",
             reply_token=reply_token,
             user_id=user_id,
+            raw_message=message,
+            message_type=media_type,
+            event_time=datetime.utcnow(),
         )
 
     @staticmethod
@@ -144,14 +174,34 @@ class LineEventHandler:
         return "file"
 
     async def _invoke_and_reply(
-        self, user_text: str, reply_token: str, user_id: Optional[str] = None
+        self,
+        user_text: str,
+        reply_token: str,
+        user_id: Optional[str] = None,
+        raw_message: Optional[object] = None,
+        message_type: str = "text",
+        event_time: Optional[datetime] = None,
     ) -> bool:
         """呼叫 Agent 並回覆訊息"""
         try:
             logger.info(f"Processing message from user {user_id}: {user_text[:50]}...")
 
-            # 呼叫 Agent 進行決策
-            result = await self._agent.invoke(user_input=user_text)
+            # 在 呼叫 Agent 之前，設定 consultation context，讓下游服務可以取用
+            from app.services.consultation.context import (
+                ConsultationContext,
+                consultation_context_scope,
+            )
+
+            context = ConsultationContext(
+                line_id=user_id,
+                message_type=message_type,
+                event_time=event_time,
+                raw_message=raw_message,
+            )
+
+            # 呼叫 Agent 進行決策（在 context scope 內）
+            with consultation_context_scope(context):
+                result = await self._agent.invoke(user_input=user_text)
 
             # 回傳 Agent 最終產出的文字回覆
             response_text = (

--- a/tests/unit/repositories/test_consultation_repository.py
+++ b/tests/unit/repositories/test_consultation_repository.py
@@ -1,0 +1,25 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.repositories.consultation_repository import (
+    SUMMARY_TTL_SECONDS,
+    ConsultationRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_creates_summary_ttl_index(monkeypatch):
+    collection = AsyncMock()
+    monkeypatch.setattr(
+        "app.repositories.consultation_repository.MongoDBManager.get_consultation_summaries_collection",
+        lambda: collection,
+    )
+
+    await ConsultationRepository.ensure_indexes()
+
+    collection.create_index.assert_awaited_once_with(
+        [("created_at", 1)],
+        expireAfterSeconds=SUMMARY_TTL_SECONDS,
+        name="consultation_summary_created_at_ttl",
+    )

--- a/tests/unit/repositories/test_consultation_repository.py
+++ b/tests/unit/repositories/test_consultation_repository.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
+from datetime import date
 
 import pytest
 
@@ -23,3 +24,39 @@ async def test_ensure_indexes_creates_summary_ttl_index(monkeypatch):
         expireAfterSeconds=SUMMARY_TTL_SECONDS,
         name="consultation_summary_created_at_ttl",
     )
+
+
+@pytest.mark.asyncio
+async def test_list_summaries_returns_sorted_user_history(monkeypatch):
+    collection = MagicMock()
+    cursor = AsyncMock()
+    collection.find.return_value = cursor
+    cursor.sort.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.to_list.return_value = [
+        {
+            "line_id": "U123",
+            "summary_date": date(2026, 5, 26),
+            "summary": "5/26 摘要",
+            "created_at": date(2026, 5, 26),
+            "_id": "mongo-id-1",
+        },
+        {
+            "line_id": "U123",
+            "summary_date": date(2026, 5, 25),
+            "summary": "5/25 摘要",
+            "created_at": date(2026, 5, 25),
+            "_id": "mongo-id-2",
+        },
+    ]
+    monkeypatch.setattr(
+        "app.repositories.consultation_repository.MongoDBManager.get_consultation_summaries_collection",
+        lambda: collection,
+    )
+
+    summaries = await ConsultationRepository.get_all_summaries("U123")
+
+    collection.find.assert_called_once_with({"line_id": "U123"})
+    cursor.sort.assert_called_once_with("summary_date", -1)
+    cursor.to_list.assert_awaited_once_with(length=None)
+    assert [summary.summary for summary in summaries] == ["5/26 摘要", "5/25 摘要"]

--- a/tests/unit/routers/test_upsert_users.py
+++ b/tests/unit/routers/test_upsert_users.py
@@ -59,7 +59,6 @@ def _valid_payload() -> dict:
         "chronic_history": "無",
         "major_illness_history": "無",
         "surgery_history": "無",
-        "health_consultations": {"last_visit": "2026-04-20"},
     }
 
 

--- a/tests/unit/services/consultation/test_consultation_service.py
+++ b/tests/unit/services/consultation/test_consultation_service.py
@@ -20,25 +20,24 @@ from app.services.consultation.consultation_service import ConsultationService
 
 class FakeStore:
     def __init__(self) -> None:
-        self.messages: dict[date, list[ConsultationMessage]] = {}
+        self.messages: dict[str, list[ConsultationMessage]] = {}
 
-    async def append_message(
-        self, line_id: str, summary_date: date, message: ConsultationMessage
-    ) -> None:
-        self.messages.setdefault(summary_date, []).append(message)
+    async def append_message(self, line_id: str, message: ConsultationMessage) -> None:
+        self.messages.setdefault(line_id, []).append(message)
 
-    async def list_messages(
-        self, line_id: str, summary_date: date
-    ) -> list[ConsultationMessage]:
-        return list(self.messages.get(summary_date, []))
+    async def list_messages(self, line_id: str) -> list[ConsultationMessage]:
+        return list(self.messages.get(line_id, []))
 
     async def list_dates(self, line_id: str) -> list[date]:
-        return sorted(self.messages)
+        return sorted(
+            {message.timestamp.date() for message in self.messages.get(line_id, [])}
+        )
 
 
 class FakeRepository:
     def __init__(self) -> None:
         self.summary: ConsultationSummary | None = None
+        self.summaries: list[ConsultationSummary] = []
 
     async def get_summary(self, line_id: str, target_date: date):
         if (
@@ -57,6 +56,9 @@ class FakeRepository:
     async def upsert_summary(self, summary: ConsultationSummary):
         self.summary = summary
         return summary
+
+    async def get_all_summaries(self, line_id: str):
+        return [summary for summary in self.summaries if summary.line_id == line_id]
 
 
 @pytest.fixture
@@ -88,9 +90,7 @@ async def test_record_user_message_stores_context_metadata(
         )
 
     assert result.stored is True
-    stored_messages = await consultation_service._store.list_messages(
-        "U123", date(2026, 5, 17)
-    )
+    stored_messages = await consultation_service._store.list_messages("U123")
     assert stored_messages[0].message_type == "image"
     # raw_text 由 _normalize_raw_text 從 raw_message.id 提取
     assert stored_messages[0].raw_text == "M1"
@@ -112,9 +112,7 @@ async def test_record_assistant_message_stores_reply(
         )
 
     assert result.stored is True
-    stored_messages = await consultation_service._store.list_messages(
-        "U123", datetime.now(timezone.utc).date()
-    )
+    stored_messages = await consultation_service._store.list_messages("U123")
     assert stored_messages[0].message_type == "assistant_reply"
     assert stored_messages[0].content == "請多喝水並觀察症狀"
 
@@ -136,6 +134,42 @@ async def test_get_view_prefers_summary(
     assert view.view_type == "summary"
     assert view.summary == "今天主要是腸胃不適"
     assert view.messages == []
+
+
+@pytest.mark.asyncio
+async def test_get_view_without_summary_does_not_fallback_to_raw(
+    consultation_service: ConsultationService,
+):
+    view = await consultation_service.get_view("U123")
+
+    assert view.view_type == "summary"
+    assert view.summary is None
+    assert view.messages == []
+
+
+@pytest.mark.asyncio
+async def test_list_summary_history_returns_repository_data(
+    consultation_service: ConsultationService,
+):
+    consultation_service._repository.summaries = [
+        ConsultationSummary(
+            line_id="U123",
+            summary_date=date(2026, 5, 26),
+            summary="5/26 摘要",
+            created_at=datetime.now(timezone.utc),
+        ),
+        ConsultationSummary(
+            line_id="U999",
+            summary_date=date(2026, 5, 26),
+            summary="別人摘要",
+            created_at=datetime.now(timezone.utc),
+        ),
+    ]
+
+    summaries = await consultation_service.get_all_summaries("U123")
+
+    assert len(summaries) == 1
+    assert summaries[0].summary == "5/26 摘要"
 
 
 @pytest.mark.asyncio
@@ -174,3 +208,103 @@ async def test_summarize_uses_generated_text(
 
     assert summary.summary == "摘要完成"
     assert consultation_service._repository.summary is not None
+    assert consultation_service._repository.summary.summary_date == date(2026, 5, 17)
+
+
+@pytest.mark.asyncio
+async def test_summarize_without_target_date_includes_cross_midnight_messages(
+    consultation_service: ConsultationService,
+    monkeypatch,
+):
+    context = ConsultationContext(line_id="U123", message_type="text")
+    with consultation_context_scope(context):
+        await consultation_service._store.append_message(
+            "U123",
+            ConsultationMessage(
+                line_id="U123",
+                message_type="text",
+                content="23:59 的訊息",
+                raw_text="23:59 的訊息",
+                timestamp=datetime(2026, 5, 26, 23, 59, tzinfo=timezone.utc),
+            ),
+        )
+        await consultation_service._store.append_message(
+            "U123",
+            ConsultationMessage(
+                line_id="U123",
+                message_type="text",
+                content="00:00 的訊息",
+                raw_text="00:00 的訊息",
+                timestamp=datetime(2026, 5, 27, 0, 0, tzinfo=timezone.utc),
+            ),
+        )
+
+    captured_messages: list[ConsultationMessage] = []
+
+    async def fake_generate_summary(user_id: str, target_date: date, messages):
+        captured_messages.extend(messages)
+        return "跨午夜摘要"
+
+    monkeypatch.setattr(
+        consultation_service, "_generate_summary", fake_generate_summary
+    )
+
+    summary = await consultation_service.summarize(
+        "U123", ConsultationSummarizeRequest()
+    )
+
+    assert summary.summary == "跨午夜摘要"
+    assert [message.content for message in captured_messages] == [
+        "23:59 的訊息",
+        "00:00 的訊息",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_summarize_ignores_target_date_and_uses_full_conversation(
+    consultation_service: ConsultationService,
+    monkeypatch,
+):
+    context = ConsultationContext(line_id="U123", message_type="text")
+    with consultation_context_scope(context):
+        await consultation_service._store.append_message(
+            "U123",
+            ConsultationMessage(
+                line_id="U123",
+                message_type="text",
+                content="5/26 的訊息",
+                raw_text="5/26 的訊息",
+                timestamp=datetime(2026, 5, 26, 23, 59, tzinfo=timezone.utc),
+            ),
+        )
+        await consultation_service._store.append_message(
+            "U123",
+            ConsultationMessage(
+                line_id="U123",
+                message_type="text",
+                content="5/27 的訊息",
+                raw_text="5/27 的訊息",
+                timestamp=datetime(2026, 5, 27, 0, 0, tzinfo=timezone.utc),
+            ),
+        )
+
+    captured_messages: list[ConsultationMessage] = []
+
+    async def fake_generate_summary(user_id: str, target_date: date, messages):
+        captured_messages.extend(messages)
+        return "忽略 target_date"
+
+    monkeypatch.setattr(
+        consultation_service, "_generate_summary", fake_generate_summary
+    )
+
+    summary = await consultation_service.summarize(
+        "U123", ConsultationSummarizeRequest(target_date=date(2026, 5, 26))
+    )
+
+    assert summary.summary == "忽略 target_date"
+    assert summary.summary_date == date(2026, 5, 27)
+    assert [message.content for message in captured_messages] == [
+        "5/26 的訊息",
+        "5/27 的訊息",
+    ]

--- a/tests/unit/services/consultation/test_consultation_service.py
+++ b/tests/unit/services/consultation/test_consultation_service.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.consultation import (
+    ConsultationMessage,
+    ConsultationSummary,
+    ConsultationSummarizeRequest,
+)
+from app.services.consultation.context import (
+    ConsultationContext,
+    consultation_context_scope,
+)
+from app.services.consultation.consultation_service import ConsultationService
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.messages: dict[date, list[ConsultationMessage]] = {}
+
+    async def append_message(
+        self, line_id: str, summary_date: date, message: ConsultationMessage
+    ) -> None:
+        self.messages.setdefault(summary_date, []).append(message)
+
+    async def list_messages(
+        self, line_id: str, summary_date: date
+    ) -> list[ConsultationMessage]:
+        return list(self.messages.get(summary_date, []))
+
+    async def list_dates(self, line_id: str) -> list[date]:
+        return sorted(self.messages)
+
+
+class FakeRepository:
+    def __init__(self) -> None:
+        self.summary: ConsultationSummary | None = None
+
+    async def get_summary(self, line_id: str, target_date: date):
+        if (
+            self.summary
+            and self.summary.line_id == line_id
+            and self.summary.summary_date == target_date
+        ):
+            return self.summary
+        return None
+
+    async def get_latest_summary(self, line_id: str):
+        return (
+            self.summary if self.summary and self.summary.line_id == line_id else None
+        )
+
+    async def upsert_summary(self, summary: ConsultationSummary):
+        self.summary = summary
+        return summary
+
+
+@pytest.fixture
+def consultation_service() -> ConsultationService:
+    fake_store = FakeStore()
+    fake_repo = FakeRepository()
+    fake_gemini = SimpleNamespace(_chat_llm=SimpleNamespace(ainvoke=AsyncMock()))
+    return ConsultationService(
+        store=fake_store, repository=fake_repo, gemini_service=fake_gemini
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_user_message_stores_context_metadata(
+    consultation_service: ConsultationService,
+):
+    # 模擬 LINE image 訊息物件
+    image_message = SimpleNamespace(type="image", id="M1")
+    context = ConsultationContext(
+        line_id="U123",
+        message_type="image",
+        event_time=datetime(2026, 5, 17, 8, 0, tzinfo=timezone.utc),
+        raw_message=image_message,
+    )
+
+    with consultation_context_scope(context):
+        result = await consultation_service.record_user_message(
+            "這是一張紅疹照片的分析文字"
+        )
+
+    assert result.stored is True
+    stored_messages = await consultation_service._store.list_messages(
+        "U123", date(2026, 5, 17)
+    )
+    assert stored_messages[0].message_type == "image"
+    # raw_text 由 _normalize_raw_text 從 raw_message.id 提取
+    assert stored_messages[0].raw_text == "M1"
+    assert stored_messages[0].content == "這是一張紅疹照片的分析文字"
+    assert stored_messages[0].timestamp == datetime(
+        2026, 5, 17, 8, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_assistant_message_stores_reply(
+    consultation_service: ConsultationService,
+):
+    context = ConsultationContext(line_id="U123", message_type="text")
+
+    with consultation_context_scope(context):
+        result = await consultation_service.record_assistant_message(
+            "請多喝水並觀察症狀"
+        )
+
+    assert result.stored is True
+    stored_messages = await consultation_service._store.list_messages(
+        "U123", datetime.now(timezone.utc).date()
+    )
+    assert stored_messages[0].message_type == "assistant_reply"
+    assert stored_messages[0].content == "請多喝水並觀察症狀"
+
+
+@pytest.mark.asyncio
+async def test_get_view_prefers_summary(
+    consultation_service: ConsultationService,
+):
+    summary = ConsultationSummary(
+        line_id="U123",
+        summary_date=date(2026, 5, 17),
+        summary="今天主要是腸胃不適",
+        created_at=datetime.now(timezone.utc),
+    )
+    consultation_service._repository.summary = summary
+
+    view = await consultation_service.get_view("U123", date(2026, 5, 17))
+
+    assert view.view_type == "summary"
+    assert view.summary == "今天主要是腸胃不適"
+    assert view.messages == []
+
+
+@pytest.mark.asyncio
+async def test_get_raw_view_returns_messages(
+    consultation_service: ConsultationService,
+):
+    context = ConsultationContext(line_id="U123", message_type="text")
+    with consultation_context_scope(context):
+        await consultation_service.record_user_message("肚子痛")
+
+    view = await consultation_service.get_raw_view(
+        "U123", datetime.now(timezone.utc).date()
+    )
+
+    assert view.view_type == "raw"
+    assert len(view.messages) == 1
+    assert view.messages[0].content == "肚子痛"
+
+
+@pytest.mark.asyncio
+async def test_summarize_uses_generated_text(
+    consultation_service: ConsultationService,
+    monkeypatch,
+):
+    context = ConsultationContext(line_id="U123", message_type="text")
+    with consultation_context_scope(context):
+        await consultation_service.record_user_message("今天肚子痛")
+
+    monkeypatch.setattr(
+        consultation_service, "_generate_summary", AsyncMock(return_value="摘要完成")
+    )
+
+    summary = await consultation_service.summarize(
+        "U123", ConsultationSummarizeRequest(target_date=date.today())
+    )
+
+    assert summary.summary == "摘要完成"
+    assert consultation_service._repository.summary is not None


### PR DESCRIPTION
1.去除redis儲存對話欄位中冗的ai_analyze_text，因為用不到
2.後端API新增取得該user所有摘要，方便前端瀏覽
3.redis依照userId創立collection後，不再依照日期細分，避免跨日bug(23:59傳訊息，24:00因為依照日期抓對話紀錄，導致看不到1分鐘前的訊息)
4.env有新增設定欄位，詳見.env.example
5.main.py加上排程器，用lifespan控制app啟動與shutdown時要做的事，達到每24小時做一次摘要

測試環境:
後端:consult_history2分支
前端:thugcreeper分支